### PR TITLE
turn on jsonp support

### DIFF
--- a/hosting-app/app.js
+++ b/hosting-app/app.js
@@ -26,6 +26,7 @@ app.configure(function(){
   app.set('view engine', 'jade');
   app.set('views', __dirname + '/views');
   app.set('view options', { layout: false, pretty: true, });
+  app.set("jsonp callback", true);
   app.register('.txt',  expressHogan);
   app.use(express.bodyParser());
   app.use(express.methodOverride());

--- a/instance-app/app.js
+++ b/instance-app/app.js
@@ -93,6 +93,7 @@ app.configure(function(){
       pretty: true,
       // debug: true,
   });
+  app.set("jsonp callback", true);
   
   app.use(express.bodyParser());
   app.use(express.methodOverride());


### PR DESCRIPTION
this simply enables the jsonp setting in express so you can get json requests using http://en.wikipedia.org/wiki/JSONP
