### PR TITLE
Fix a problem that prevents firefox users from adding a new site

### DIFF
--- a/public/js/slug-validation.js
+++ b/public/js/slug-validation.js
@@ -26,7 +26,7 @@ require(['jquery'], function($) {
 	    keypress: function(e) {
 	      // Return True/False to prevent or allow the key being pressed or add an 
 	      //error class to display the hint when a disallowed key is pressed
-	      return check_allowed_letter(e.keyCode);
+	      return check_allowed_letter(e.which);
 	    },
 	    change: function(e) {
       	// Check pasted text


### PR DESCRIPTION
If you want to create a new site you have to choose a name. In Firefox 13 it is not possible to type in a name. The input validation of the slug field checks whether the keyCode is ok. However, sometimes the code is stored in keyChar. $.which fixes that. Read more on https://developer.mozilla.org/en/DOM/event.charCode#Notes.

And about which: http://api.jquery.com/event.which/
