### PR TITLE
Fix browser test failures under ruby 2.0

### DIFF
--- a/tests/browser_based/hosting.rb
+++ b/tests/browser_based/hosting.rb
@@ -75,8 +75,8 @@ class HostingTests < PopItWatirTestCase
     # check that a good slug does not error
     @b.text_field(:name, 'slug').set("test")
     @b.input(:value, 'Create your own PopIt').click
-    assert_not_match "Error is 'regexp'", @b.text
-    assert_match "Error is 'required'", @b.text    
+    assert_not_match Regexp.new("Error is 'regexp'"), @b.text
+    assert_match Regexp.new("Error is 'required'"), @b.text
     
     # check that a bad email is rejected
     #   NOTE - these tests are commented out as recent browsers catch the bad

--- a/tests/browser_based/instance_searching.rb
+++ b/tests/browser_based/instance_searching.rb
@@ -29,7 +29,7 @@ class InstanceSearchingTests < PopItWatirTestCase
   def test_empty_search
     prep_for_test
     run_search ''
-    assert_match @b.text, /Sorry, no results/
+    assert_match /Sorry, no results/, @b.text
   end    
 
   def test_single_result_search

--- a/tests/browser_based/membership_editing.rb
+++ b/tests/browser_based/membership_editing.rb
@@ -65,11 +65,11 @@ class MembershipEditingTests < PopItWatirTestCase
       # submit the form and check that the new membership is created
       membership_form.submit
       @b.wait_until { ! membership_form.present? }
-      assert_match @b.text, /\(President\)\ :\ United\ States\ Government\ \(\ from\ 2001-01-20\ \)/
+      assert_match /\(President\)\ :\ United\ States\ Government\ \(\ from\ 2001-01-20\ \)/, @b.text
 
       # go back to person page and check that the membership is now listed there
       goto '/persons/george-bush'
-      assert_match @b.section(:class, 'memberships').text, /President/
+      assert_match /President/, @b.section(:class, 'memberships').text
 
       # create a new membership but with new role and organization
       @b.section(:class, 'memberships').link(:class, 'add').click
@@ -89,7 +89,7 @@ class MembershipEditingTests < PopItWatirTestCase
 
       membership_form.submit
       @b.wait_until { ! membership_form.present? }
-      assert_match @b.text, /\(Bottle Washer\)\ :\ 1600\ Penn\ Hotel/
+      assert_match /\(Bottle Washer\)\ :\ 1600\ Penn\ Hotel/, @b.text
 
       # check that the new role and org are in the possible options
       goto '/persons/george-bush'
@@ -139,7 +139,7 @@ class MembershipEditingTests < PopItWatirTestCase
 
       membership_form.submit
       @b.wait_until { ! membership_form.present? }
-      assert_match @b.text, /\(President\)\ :\ United\ States\ Government\ \(\ to\ 2013-01-01\ \)/
+      assert_match /\(President\)\ :\ United\ States\ Government\ \(\ to\ 2013-01-01\ \)/, @b.text
     }
   end
 

--- a/tests/browser_based/photos.rb
+++ b/tests/browser_based/photos.rb
@@ -42,7 +42,7 @@ class PhotoTests < PopItWatirTestCase
       
       # check that only the placeholder photo is shown to start with
       assert @b.ul(:class => 'photos').li.img.present?
-      assert_match @b.ul(:class => 'photos').li.img.attribute_value('src'), opts[:placeholder_filename_regex]
+      assert_match opts[:placeholder_filename_regex], @b.ul(:class => 'photos').li.img.attribute_value('src')
       
       # upload a file
       @b.link(:text => '+ add a photograph').click
@@ -63,7 +63,7 @@ class PhotoTests < PopItWatirTestCase
       # check that the photo is now gone
       assert_path opts[:url]
       assert @b.ul(:class => 'photos').li.img.present?
-      assert_match @b.ul(:class => 'photos').li.img.attribute_value('src'), opts[:placeholder_filename_regex]
+      assert_match opts[:placeholder_filename_regex], @b.ul(:class => 'photos').li.img.attribute_value('src')
     }
   end 
 


### PR DESCRIPTION
Make sure that the regex (or matcher) is always the first argument in calls to `assert_match` and `assert_not_match`.

Fixes https://github.com/mysociety/popit/issues/257
