### PR TITLE
Fix Firefox browser tests

### DIFF
--- a/tests/browser_based/membership_editing.rb
+++ b/tests/browser_based/membership_editing.rb
@@ -14,11 +14,13 @@ class MembershipEditingTests < PopItWatirTestCase
   include Select2Helpers
 
   def edit_link
+    @b.execute_script('arguments[0].scrollIntoView();', @b.section(:class, 'memberships'))
     @b.section(:class, 'memberships').li.hover
     @b.section(:class, 'memberships').li.link(:text => 'Edit').click
   end
 
   def delete_link
+    @b.execute_script('arguments[0].scrollIntoView();', @b.section(:class, 'memberships'))
     @b.section(:class, 'memberships').li.hover
     @b.section(:class, 'memberships').li.link(:text => 'Delete').click
   end

--- a/tests/browser_based/person_edit_list_details.rb
+++ b/tests/browser_based/person_edit_list_details.rb
@@ -11,6 +11,7 @@ require 'uri'
 class PersonContactDetailEditingTests < PopItWatirTestCase
 
   def edit_link(e)
+    @b.execute_script('arguments[0].scrollIntoView();', @b.element(e).parent)
     @b.element(e).hover
     @b.element(e).parent.link(:text => 'Edit').click
   end


### PR DESCRIPTION
In firefox it seems that the hover then click combo only works for
elements that are visible in the viewport. When an element is outside
the viewport these tests fail with a
`Selenium::WebDriver::Error::ElementNotVisibleError` when run with the
firefox driver.

This patch uses javascript to scroll the required element into view
before interacting with it, which fixes these failures when I run
against firefox locally. Hopefully it will also fix the travis build as well.

Fixes https://github.com/mysociety/popit/issues/259
