### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -33,4 +33,4 @@ All `GET` requests are returned `JSON` responses. These will have the form:
 ```
 
 The exact format of the response depends on the schema of the collection you
-are looking at. Please see [Schemas](../schemas) for more details.
+are looking at. Please see [Schemas](/docs/api/schemas) for more details.

--- a/docs/api/writing.md
+++ b/docs/api/writing.md
@@ -8,7 +8,7 @@ It should be possible to manage all the public data stored in a PopIt instance u
 
 (Note - there is currently some data that cannot be managed using the API, notably image uploads.)
 
-To edit data you will need to [authenticate your requests](../auth).
+To edit data you will need to [authenticate your requests](/docs/api/auth).
 
 ## Method summary
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,9 +15,9 @@ We run a free [PopIt hosting service](http://popit.mysociety.org/) - if you just
 
 There are specific install instructions for some platforms:
 
-  * [MacOS X](macos)
-  * [Ubuntu](ubuntu)
-  * [Vagrant](vagrant)
+  * [MacOS X](/docs/install/macos)
+  * [Ubuntu](/docs/install/ubuntu)
+  * [Vagrant](/docs/install/vagrant)
 
 ## Configuration
 


### PR DESCRIPTION
Use absolute links rather than relative ones to prevent 404s.

Closes #271 
