### PR TITLE
Update npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,250 +1,366 @@
 {
   "name": "popit",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "dependencies": {
     "async": {
-      "version": "0.1.22"
+      "version": "0.1.22",
+      "from": "async@0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
     },
     "bcrypt": {
       "version": "0.7.5",
+      "from": "bcrypt@0.7.5",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.7.5.tgz",
       "dependencies": {
         "bindings": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "from": "bindings@1.0.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.0.0.tgz"
         }
       }
     },
     "bson": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "from": "bson@0.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.1.5.tgz"
     },
     "config": {
-      "version": "0.4.18"
+      "version": "0.4.18",
+      "from": "config@0.4.18",
+      "resolved": "https://registry.npmjs.org/config/-/config-0.4.18.tgz"
     },
     "connect": {
       "version": "2.7.0",
+      "from": "connect@2.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.7.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "0.5.1"
+          "version": "0.5.1",
+          "from": "qs@0.5.1"
         },
         "formidable": {
-          "version": "1.0.11"
+          "version": "1.0.11",
+          "from": "formidable@1.0.11"
         },
         "cookie-signature": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "cookie-signature@0.0.1",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
         },
         "crc": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "crc@0.2.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-0.2.0.tgz"
         },
         "cookie": {
-          "version": "0.0.5"
+          "version": "0.0.5",
+          "from": "cookie@0.0.5"
         },
         "bytes": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "from": "bytes@0.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz"
         },
         "send": {
           "version": "0.1.0",
+          "from": "send@0.1.0",
           "dependencies": {
             "mime": {
-              "version": "1.2.6"
+              "version": "1.2.6",
+              "from": "mime@1.2.6"
             },
             "range-parser": {
-              "version": "0.0.4"
+              "version": "0.0.4",
+              "from": "range-parser@0.0.4"
             }
           }
         },
         "fresh": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "from": "fresh@0.1.0"
         },
         "pause": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "pause@0.0.1"
         },
         "debug": {
-          "version": "0.7.0"
+          "version": "0.7.0",
+          "from": "debug@0.7.0"
         }
       }
     },
     "connect-flash": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "connect-flash@0.1.0",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.0.tgz"
     },
     "connect-image-proxy": {
       "version": "0.0.5",
+      "from": "connect-image-proxy@0.0.5",
+      "resolved": "https://registry.npmjs.org/connect-image-proxy/-/connect-image-proxy-0.0.5.tgz",
       "dependencies": {
         "gm": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "from": "gm@1.3.2",
+          "resolved": "https://registry.npmjs.org/gm/-/gm-1.3.2.tgz"
         },
         "temp": {
-          "version": "0.4.0"
+          "version": "0.4.0",
+          "from": "temp@0.4.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
         }
       }
     },
     "connect-mongodb": {
       "version": "1.1.5",
+      "from": "connect-mongodb@1.1.5",
+      "resolved": "https://registry.npmjs.org/connect-mongodb/-/connect-mongodb-1.1.5.tgz",
       "dependencies": {
         "connect": {
           "version": "1.9.2",
+          "from": "connect@1.9.2",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
           "dependencies": {
             "qs": {
-              "version": "0.5.3"
+              "version": "0.5.3",
+              "from": "qs@0.5.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.3.tgz"
             },
             "formidable": {
-              "version": "1.0.11"
+              "version": "1.0.11",
+              "from": "formidable@1.0.11"
             }
           }
         }
       }
     },
     "consolidate": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "from": "consolidate@0.5.0",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.5.0.tgz"
     },
     "csv": {
-      "version": "0.2.4"
+      "version": "0.2.4",
+      "from": "csv@0.2.4",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-0.2.4.tgz"
     },
     "doublemetaphone": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "from": "doublemetaphone@0.1.0",
+      "resolved": "https://registry.npmjs.org/doublemetaphone/-/doublemetaphone-0.1.0.tgz"
     },
     "express": {
       "version": "3.0.3",
+      "from": "express@3.0.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.0.3.tgz",
       "dependencies": {
         "commander": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "from": "commander@0.6.1"
         },
         "range-parser": {
-          "version": "0.0.4"
+          "version": "0.0.4",
+          "from": "range-parser@0.0.4"
         },
         "mkdirp": {
-          "version": "0.3.3"
+          "version": "0.3.3",
+          "from": "mkdirp@0.3.3"
         },
         "cookie": {
-          "version": "0.0.5"
+          "version": "0.0.5",
+          "from": "cookie@0.0.5"
         },
         "crc": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "from": "crc@0.2.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-0.2.0.tgz"
         },
         "fresh": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "from": "fresh@0.1.0"
         },
         "methods": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "methods@0.0.1"
         },
         "send": {
           "version": "0.1.0",
+          "from": "send@0.1.0",
           "dependencies": {
             "mime": {
-              "version": "1.2.6"
+              "version": "1.2.6",
+              "from": "mime@1.2.6"
             }
           }
         },
         "cookie-signature": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "cookie-signature@0.0.1",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
         },
         "debug": {
-          "version": "0.7.0"
+          "version": "0.7.0",
+          "from": "debug@0.7.0"
         }
       }
     },
     "form-data": {
       "version": "0.0.4",
+      "from": "form-data@0.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.4.tgz",
       "dependencies": {
         "combined-stream": {
           "version": "0.0.3",
+          "from": "combined-stream@0.0.3",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.3.tgz",
           "dependencies": {
             "delayed-stream": {
-              "version": "0.0.5"
+              "version": "0.0.5",
+              "from": "delayed-stream@0.0.5",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
             }
           }
         }
       }
     },
     "hogan.js": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "from": "hogan.js@2.0.0",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-2.0.0.tgz"
     },
     "iconv": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "from": "iconv@1.2.4",
+      "resolved": "https://registry.npmjs.org/iconv/-/iconv-1.2.4.tgz"
     },
     "jquery": {
       "version": "1.8.2",
+      "from": "jquery@1.8.2",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.8.2.tgz",
       "dependencies": {
         "jsdom": {
           "version": "0.2.19",
+          "from": "jsdom@0.2.19",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.2.19.tgz",
           "dependencies": {
             "request": {
               "version": "2.12.0",
+              "from": "request@2.12.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.12.0.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.3",
+                  "from": "form-data",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.3",
+                      "from": "combined-stream@0.0.3",
                       "dependencies": {
                         "delayed-stream": {
-                          "version": "0.0.5"
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
                         }
                       }
                     },
                     "async": {
-                      "version": "0.1.9"
+                      "version": "0.1.9",
+                      "from": "async@0.1.9"
                     }
                   }
                 },
                 "mime": {
-                  "version": "1.2.7"
+                  "version": "1.2.7",
+                  "from": "mime"
                 }
               }
             },
             "cssom": {
-              "version": "0.2.5"
+              "version": "0.2.5",
+              "from": "cssom@0.2.5",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.2.5.tgz"
             },
             "cssstyle": {
-              "version": "0.2.3"
+              "version": "0.2.3",
+              "from": "cssstyle@0.2.3",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.3.tgz"
             },
             "contextify": {
               "version": "0.1.3",
+              "from": "contextify@0.1.3",
+              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.3.tgz",
               "dependencies": {
                 "bindings": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "bindings@1.0.0",
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.0.0.tgz"
                 }
               }
             }
           }
         },
         "htmlparser": {
-          "version": "1.7.6"
+          "version": "1.7.6",
+          "from": "htmlparser@1.7.6",
+          "resolved": "https://registry.npmjs.org/htmlparser/-/htmlparser-1.7.6.tgz"
         },
         "xmlhttprequest": {
-          "version": "1.4.2"
+          "version": "1.4.2",
+          "from": "xmlhttprequest@1.4.2",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
         },
         "location": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "from": "location@0.0.1",
+          "resolved": "https://registry.npmjs.org/location/-/location-0.0.1.tgz"
         },
         "navigator": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "from": "navigator@1.0.1",
+          "resolved": "https://registry.npmjs.org/navigator/-/navigator-1.0.1.tgz"
         }
       }
     },
     "jshint": {
       "version": "0.9.1",
+      "from": "jshint@0.9.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
       "dependencies": {
         "cli": {
           "version": "0.4.3",
+          "from": "cli@0.4.3",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.1.14",
+              "from": "glob@3.1.14",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.14.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.9",
+                  "from": "minimatch@0.2.9",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.9.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.0.4"
+                      "version": "2.0.4",
+                      "from": "lru-cache@2.0.4",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.0.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0"
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "1.1.14"
+                  "version": "1.1.14",
+                  "from": "graceful-fs@1.1.14",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz"
                 },
                 "inherits": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "inherits@1.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                 }
               }
             }
@@ -252,9 +368,13 @@
         },
         "minimatch": {
           "version": "0.0.5",
+          "from": "minimatch@0.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "1.0.6"
+              "version": "1.0.6",
+              "from": "lru-cache@1.0.6",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz"
             }
           }
         }
@@ -262,15 +382,23 @@
     },
     "js-yaml": {
       "version": "1.0.3",
+      "from": "js-yaml@1.0.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-1.0.3.tgz",
       "dependencies": {
         "argparse": {
           "version": "0.1.8",
+          "from": "argparse@0.1.8",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.8.tgz",
           "dependencies": {
             "underscore": {
-              "version": "1.3.3"
+              "version": "1.3.3",
+              "from": "underscore@1.3.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
             },
             "underscore.string": {
-              "version": "2.1.1"
+              "version": "2.1.1",
+              "from": "underscore.string@2.1.1",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.1.1.tgz"
             }
           }
         }
@@ -278,30 +406,48 @@
     },
     "markx": {
       "version": "0.2.1",
+      "from": "markx@0.2.1",
+      "resolved": "https://registry.npmjs.org/markx/-/markx-0.2.1.tgz",
       "dependencies": {
         "aug": {
-          "version": "0.0.5"
+          "version": "0.0.5",
+          "from": "aug@0.0.5",
+          "resolved": "https://registry.npmjs.org/aug/-/aug-0.0.5.tgz"
         },
         "highlight.js": {
-          "version": "7.3.0"
+          "version": "7.3.0",
+          "from": "highlight.js@7.3.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-7.3.0.tgz"
         },
         "ejs": {
-          "version": "0.8.3"
+          "version": "0.8.3",
+          "from": "ejs@0.8.3",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.3.tgz"
         },
         "marked": {
-          "version": "0.2.5"
+          "version": "0.2.5",
+          "from": "marked@0.2.5",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.2.5.tgz"
         },
         "js-yaml": {
           "version": "1.0.2",
+          "from": "js-yaml@1.0.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-1.0.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.8",
+              "from": "argparse@0.1.8",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.8.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.3.3"
+                  "version": "1.3.3",
+                  "from": "underscore@1.3.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
                 },
                 "underscore.string": {
-                  "version": "2.1.1"
+                  "version": "2.1.1",
+                  "from": "underscore.string@2.1.1",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.1.1.tgz"
                 }
               }
             }
@@ -309,73 +455,111 @@
         },
         "optimist": {
           "version": "0.3.4",
+          "from": "optimist@0.3.4",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2"
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         },
         "resistance": {
-          "version": "2.0.0alpha4"
+          "version": "2.0.0-alpha4",
+          "from": "resistance@2.0.0alpha4",
+          "resolved": "https://registry.npmjs.org/resistance/-/resistance-2.0.0alpha4.tgz"
         }
       }
     },
     "mime": {
-      "version": "1.2.7"
+      "version": "1.2.7",
+      "from": "mime@1.2.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.7.tgz"
     },
     "mkdirp": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "from": "mkdirp@0.3.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.4.tgz"
     },
     "moment": {
-      "version": "1.7.2"
+      "version": "1.7.2",
+      "from": "moment@1.7.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-1.7.2.tgz"
     },
     "moment-range": {
       "version": "0.1.3",
+      "from": "moment-range@0.1.3",
+      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-0.1.3.tgz",
       "dependencies": {
         "moment": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "from": "moment@1.3.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-1.3.0.tgz"
         }
       }
     },
     "mongodb": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "from": "mongodb@1.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.2.0.tgz"
     },
     "mongoose": {
       "version": "3.4.0",
+      "from": "mongoose@3.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.4.0.tgz",
       "dependencies": {
         "hooks": {
-          "version": "0.2.1"
+          "version": "0.2.1",
+          "from": "hooks@0.2.1"
         },
         "mongodb": {
-          "version": "1.1.11"
+          "version": "1.1.11",
+          "from": "mongodb@1.1.11",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.1.11.tgz"
         },
         "ms": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "from": "ms@0.1.0"
         },
         "sliced": {
-          "version": "0.0.3"
+          "version": "0.0.3",
+          "from": "sliced@0.0.3",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.3.tgz"
         }
       }
     },
     "nodemailer": {
       "version": "0.3.34",
+      "from": "nodemailer@0.3.34",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.3.34.tgz",
       "dependencies": {
         "mailcomposer": {
           "version": "0.1.26",
+          "from": "mailcomposer@0.1.26",
+          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.1.26.tgz",
           "dependencies": {
             "mimelib": {
               "version": "0.2.7",
+              "from": "mimelib@0.2.7",
+              "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.7.tgz",
               "dependencies": {
                 "encoding": {
                   "version": "0.1.5",
+                  "from": "encoding@0.1.5",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.5.tgz",
                   "dependencies": {
                     "iconv-lite": {
-                      "version": "0.2.6"
+                      "version": "0.2.6",
+                      "from": "iconv-lite@0.2.6",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.6.tgz"
                     }
                   }
                 },
                 "addressparser": {
-                  "version": "0.1.3"
+                  "version": "0.1.3",
+                  "from": "addressparser@0.1.3",
+                  "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.1.3.tgz"
                 }
               }
             }
@@ -383,34 +567,47 @@
         },
         "simplesmtp": {
           "version": "0.1.25",
+          "from": "simplesmtp@0.1.25",
+          "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.1.25.tgz",
           "dependencies": {
             "rai": {
-              "version": "0.1.6"
+              "version": "0.1.6",
+              "from": "rai@0.1.6",
+              "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.6.tgz"
             },
             "xoauth2": {
               "version": "0.1.3",
+              "from": "xoauth2@0.1.3",
+              "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.3.tgz",
               "dependencies": {
                 "request": {
                   "version": "2.12.0",
+                  "from": "request@2.12.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.12.0.tgz",
                   "dependencies": {
                     "form-data": {
                       "version": "0.0.3",
+                      "from": "form-data",
                       "dependencies": {
                         "combined-stream": {
                           "version": "0.0.3",
+                          "from": "combined-stream@0.0.3",
                           "dependencies": {
                             "delayed-stream": {
-                              "version": "0.0.5"
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5"
                             }
                           }
                         },
                         "async": {
-                          "version": "0.1.9"
+                          "version": "0.1.9",
+                          "from": "async@0.1.9"
                         }
                       }
                     },
                     "mime": {
-                      "version": "1.2.7"
+                      "version": "1.2.7",
+                      "from": "mime"
                     }
                   }
                 }
@@ -420,9 +617,12 @@
         },
         "optimist": {
           "version": "0.3.5",
+          "from": "optimist@0.3.5",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2"
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         }
@@ -430,9 +630,13 @@
     },
     "nodeunit": {
       "version": "0.7.4",
+      "from": "nodeunit@0.7.4",
+      "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.7.4.tgz",
       "dependencies": {
         "tap": {
           "version": "0.2.4",
+          "from": "tap@0.2.4",
+          "resolved": "https://registry.npmjs.org/tap/-/tap-0.2.4.tgz",
           "dependencies": {
             "inherits": {
               "version": "1.0.0"
@@ -441,22 +645,34 @@
               "version": "0.0.4"
             },
             "slide": {
-              "version": "1.1.3"
+              "version": "1.1.3",
+              "from": "slide@1.1.3",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.3.tgz"
             },
             "runforcover": {
               "version": "0.0.2",
+              "from": "runforcover@0.0.2",
+              "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
+                  "from": "bunker@0.1.2",
+                  "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.11",
+                      "from": "burrito@0.2.11",
+                      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.11.tgz",
                       "dependencies": {
                         "traverse": {
-                          "version": "0.5.2"
+                          "version": "0.5.2",
+                          "from": "traverse@0.5.2",
+                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
-                          "version": "1.0.7"
+                          "version": "1.0.7",
+                          "from": "uglify-js@1.0.7",
+                          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.0.7.tgz"
                         }
                       }
                     }
@@ -466,25 +682,37 @@
             },
             "nopt": {
               "version": "1.0.10",
+              "from": "nopt@1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.3"
+                  "version": "1.0.3",
+                  "from": "abbrev@1.0.3",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.3.tgz"
                 }
               }
             },
             "difflet": {
               "version": "0.2.1",
+              "from": "difflet@0.2.1",
+              "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.1.tgz",
               "dependencies": {
                 "traverse": {
-                  "version": "0.6.1"
+                  "version": "0.6.1",
+                  "from": "traverse@0.6.1",
+                  "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.1.tgz"
                 },
                 "charm": {
-                  "version": "0.0.7"
+                  "version": "0.0.7",
+                  "from": "charm@0.0.7",
+                  "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.7.tgz"
                 }
               }
             },
             "deep-equal": {
-              "version": "0.0.0"
+              "version": "0.0.0",
+              "from": "deep-equal@0.0.0",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             }
           }
         }
@@ -492,86 +720,113 @@
     },
     "passgen": {
       "version": "1.0.1",
+      "from": "passgen@1.0.1",
+      "resolved": "https://registry.npmjs.org/passgen/-/passgen-1.0.1.tgz",
       "dependencies": {
         "vows": {
           "version": "0.6.2",
+          "from": "vows@0.6.2",
+          "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.2.tgz",
           "dependencies": {
             "eyes": {
-              "version": "0.1.7"
+              "version": "0.1.7",
+              "from": "eyes@0.1.7",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.7.tgz"
             }
           }
         }
       }
     },
     "popit-api": {
-      "version": "0.0.9",
+      "version": "0.0.11",
       "from": "git://github.com/mysociety/popit-api.git",
+      "resolved": "git://github.com/mysociety/popit-api.git#0bddb34226d4da8ac9e2ca5f22ed84a4757716a5",
       "dependencies": {
         "express": {
           "version": "3.1.2",
+          "from": "express@~3.1.0",
           "dependencies": {
             "connect": {
               "version": "2.7.5",
+              "from": "connect@2.7.5",
               "dependencies": {
                 "qs": {
-                  "version": "0.5.1"
+                  "version": "0.5.1",
+                  "from": "qs@0.5.1"
                 },
                 "formidable": {
-                  "version": "1.0.11"
+                  "version": "1.0.11",
+                  "from": "formidable@1.0.11"
                 },
                 "buffer-crc32": {
-                  "version": "0.1.1"
+                  "version": "0.1.1",
+                  "from": "buffer-crc32@0.1.1"
                 },
                 "bytes": {
-                  "version": "0.2.0"
+                  "version": "0.2.0",
+                  "from": "bytes@0.2.0"
                 },
                 "pause": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "from": "pause@0.0.1"
                 }
               }
             },
             "commander": {
-              "version": "0.6.1"
+              "version": "0.6.1",
+              "from": "commander@0.6.1"
             },
             "range-parser": {
-              "version": "0.0.4"
+              "version": "0.0.4",
+              "from": "range-parser@0.0.4"
             },
             "cookie": {
-              "version": "0.0.5"
+              "version": "0.0.5",
+              "from": "cookie@0.0.5"
             },
             "buffer-crc32": {
-              "version": "0.2.1"
+              "version": "0.2.1",
+              "from": "buffer-crc32@~0.2.1"
             },
             "fresh": {
-              "version": "0.1.0"
+              "version": "0.1.0",
+              "from": "fresh@0.1.0"
             },
             "methods": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "from": "methods@0.0.1"
             },
             "send": {
               "version": "0.1.0",
+              "from": "send@0.1.0",
               "dependencies": {
                 "mime": {
-                  "version": "1.2.6"
+                  "version": "1.2.6",
+                  "from": "mime@1.2.6"
                 }
               }
             },
             "cookie-signature": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "cookie-signature@1.0.0"
             },
             "debug": {
-              "version": "0.7.2"
+              "version": "0.7.4",
+              "from": "debug@*"
             }
           }
         },
         "assert": {
           "version": "0.4.9",
+          "from": "assert@~0.4.9",
           "dependencies": {
             "util": {
-              "version": "0.4.9",
+              "version": "0.10.2",
+              "from": "util@>= 0.4.9",
               "dependencies": {
-                "events.node": {
-                  "version": "0.4.9"
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1"
                 }
               }
             }
@@ -579,84 +834,171 @@
         },
         "glob": {
           "version": "3.1.21",
+          "from": "glob@~3.1.21",
           "dependencies": {
             "minimatch": {
-              "version": "0.2.12",
+              "version": "0.2.14",
+              "from": "minimatch@~0.2.11",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.3.0"
+                  "version": "2.5.0",
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
-                  "version": "1.0.0"
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0"
                 }
               }
             },
             "graceful-fs": {
-              "version": "1.2.2"
+              "version": "1.2.3",
+              "from": "graceful-fs@~1.2.0"
             },
             "inherits": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "from": "inherits@1"
             }
           }
         },
         "underscore": {
-          "version": "1.4.4"
+          "version": "1.4.4",
+          "from": "underscore@~1.4.4"
         },
         "JSV": {
-          "version": "4.0.2"
-        },
-        "mongodb": {
-          "version": "1.2.14",
-          "dependencies": {
-            "bson": {
-              "version": "0.1.8"
-            }
-          }
+          "version": "4.0.2",
+          "from": "JSV@~4.0.2"
         },
         "async": {
-          "version": "0.2.9"
+          "version": "0.2.9",
+          "from": "async@~0.2.6"
         },
         "underscore.string": {
-          "version": "2.3.1"
+          "version": "2.3.3",
+          "from": "underscore.string@~2.3.1"
+        },
+        "doublemetaphone": {
+          "version": "0.1.2",
+          "from": "doublemetaphone@~0.1.2"
+        },
+        "unorm": {
+          "version": "1.3.1",
+          "from": "unorm@~1.3.1"
+        },
+        "mongoose": {
+          "version": "3.8.3",
+          "from": "mongoose@~3.8.2",
+          "dependencies": {
+            "hooks": {
+              "version": "0.2.1",
+              "from": "hooks@0.2.1"
+            },
+            "mongodb": {
+              "version": "1.3.19",
+              "from": "mongodb@1.3.19",
+              "dependencies": {
+                "bson": {
+                  "version": "0.2.2",
+                  "from": "bson@0.2.2"
+                },
+                "kerberos": {
+                  "version": "0.0.3",
+                  "from": "kerberos@0.0.3"
+                }
+              }
+            },
+            "ms": {
+              "version": "0.1.0",
+              "from": "ms@0.1.0"
+            },
+            "sliced": {
+              "version": "0.0.5",
+              "from": "sliced@0.0.5"
+            },
+            "muri": {
+              "version": "0.3.1",
+              "from": "muri@0.3.1"
+            },
+            "mpromise": {
+              "version": "0.3.0",
+              "from": "mpromise@0.3.0"
+            },
+            "mpath": {
+              "version": "0.1.1",
+              "from": "mpath@0.1.1"
+            },
+            "regexp-clone": {
+              "version": "0.0.1",
+              "from": "regexp-clone@0.0.1"
+            },
+            "mquery": {
+              "version": "0.3.2",
+              "from": "mquery@0.3.2",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.0",
+                  "from": "debug@0.7.0"
+                }
+              }
+            }
+          }
         }
       }
     },
     "pow-mongodb-fixtures": {
       "version": "0.8.1",
+      "from": "pow-mongodb-fixtures@0.8.1",
+      "resolved": "https://registry.npmjs.org/pow-mongodb-fixtures/-/pow-mongodb-fixtures-0.8.1.tgz",
       "dependencies": {
         "async": {
-          "version": "0.1.15"
+          "version": "0.1.15",
+          "from": "async@0.1.15"
         },
         "optimist": {
           "version": "0.3.5",
+          "from": "optimist@0.3.5",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2"
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             }
           }
         }
       }
     },
     "regexp-quote": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "from": "regexp-quote@0.0.0"
     },
     "requirejs": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "from": "requirejs@2.1.2",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.2.tgz"
     },
     "restler": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "from": "restler@2.0.1",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-2.0.1.tgz"
     },
     "slug": {
       "version": "0.2.2",
+      "from": "slug@0.2.2",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.2.2.tgz",
       "dependencies": {
         "unicode": {
           "version": "0.3.1",
+          "from": "unicode@0.3.1",
+          "resolved": "https://registry.npmjs.org/unicode/-/unicode-0.3.1.tgz",
           "dependencies": {
             "bufferstream": {
               "version": "0.5.1",
+              "from": "bufferstream@0.5.1",
+              "resolved": "https://registry.npmjs.org/bufferstream/-/bufferstream-0.5.1.tgz",
               "dependencies": {
                 "buffertools": {
-                  "version": "1.0.9"
+                  "version": "1.0.9",
+                  "from": "buffertools@1.0.9",
+                  "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-1.0.9.tgz"
                 }
               }
             }
@@ -665,30 +1007,46 @@
       }
     },
     "supervisor": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "from": "supervisor@0.5.0",
+      "resolved": "https://registry.npmjs.org/supervisor/-/supervisor-0.5.0.tgz"
     },
     "twix": {
       "version": "0.2.2",
+      "from": "twix@0.2.2",
+      "resolved": "https://registry.npmjs.org/twix/-/twix-0.2.2.tgz",
       "dependencies": {
         "moment": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "from": "moment@2.0.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz"
         }
       }
     },
     "underscore": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "from": "underscore@1.4.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.2.tgz"
     },
     "underscore-template-additions": {
       "version": "0.0.1",
+      "from": "underscore-template-additions@0.0.1",
+      "resolved": "https://registry.npmjs.org/underscore-template-additions/-/underscore-template-additions-0.0.1.tgz",
       "dependencies": {
         "walk": {
           "version": "2.2.1",
+          "from": "walk@2.2.1",
+          "resolved": "https://registry.npmjs.org/walk/-/walk-2.2.1.tgz",
           "dependencies": {
             "forEachAsync": {
               "version": "2.2.0",
+              "from": "forEachAsync@2.2.0",
+              "resolved": "https://registry.npmjs.org/forEachAsync/-/forEachAsync-2.2.0.tgz",
               "dependencies": {
                 "sequence": {
-                  "version": "2.2.1"
+                  "version": "2.2.1",
+                  "from": "sequence@2.2.1",
+                  "resolved": "https://registry.npmjs.org/sequence/-/sequence-2.2.1.tgz"
                 }
               }
             }
@@ -697,53 +1055,83 @@
       }
     },
     "unorm": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "from": "unorm@1.0.2",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.0.2.tgz"
     },
     "validator": {
-      "version": "0.4.17"
+      "version": "0.4.17",
+      "from": "validator@0.4.17",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-0.4.17.tgz"
     },
     "version": {
       "version": "0.1.0",
+      "from": "version@0.1.0",
+      "resolved": "https://registry.npmjs.org/version/-/version-0.1.0.tgz",
       "dependencies": {
         "request": {
-          "version": "2.9.202"
+          "version": "2.9.202",
+          "from": "request@2.9.202",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.9.202.tgz"
         }
       }
     },
     "winston": {
       "version": "0.6.2",
+      "from": "winston@0.6.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
       "dependencies": {
         "colors": {
-          "version": "0.6.0-1"
+          "version": "0.6.0-1",
+          "from": "colors@0.6.0-1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
         },
         "cycle": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "from": "cycle@1.0.1",
+          "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.1.tgz"
         },
         "eyes": {
-          "version": "0.1.8"
+          "version": "0.1.8",
+          "from": "eyes@0.1.8",
+          "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
         },
         "pkginfo": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "from": "pkginfo@0.2.3",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
         },
         "request": {
-          "version": "2.9.203"
+          "version": "2.9.203",
+          "from": "request@2.9.203",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
         },
         "stack-trace": {
-          "version": "0.0.6"
+          "version": "0.0.6",
+          "from": "stack-trace@0.0.6",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.6.tgz"
         }
       }
     },
     "winston-loggly": {
       "version": "0.6.0",
+      "from": "winston-loggly@0.6.0",
+      "resolved": "https://registry.npmjs.org/winston-loggly/-/winston-loggly-0.6.0.tgz",
       "dependencies": {
         "loggly": {
           "version": "0.3.11",
+          "from": "loggly@0.3.11",
+          "resolved": "https://registry.npmjs.org/loggly/-/loggly-0.3.11.tgz",
           "dependencies": {
             "request": {
-              "version": "2.9.203"
+              "version": "2.9.203",
+              "from": "request@2.9.203",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
             },
             "timespan": {
-              "version": "2.2.0"
+              "version": "2.2.0",
+              "from": "timespan@2.2.0",
+              "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.2.0.tgz"
             }
           }
         }


### PR DESCRIPTION
Includes the dependencies for the latest version of popit-api.

Updated using latest npm, so this should work correctly with newer versions of npm, older version will simply ignore fields that they don't understand.

Closes #273 
