### PR TITLE
Pass base urls to the API app

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -15,14 +15,19 @@ api_01_app.post( '*', apiRequireUserOrGuest );
 api_01_app.put(  '*', apiRequireUserOrGuest );
 api_01_app.del(  '*', apiRequireUserOrGuest );
 
+api_01_app.use(function(req, res, next) {
+  req.base_url = base_url(req);
+  req.api_base_url = req.base_url + '/api/v0.1';
+  next();
+});
+
 api_01_app.get('/', function (req, res, next) {
-  var api_base_url = base_url(req) + '/api/v0.1/';
   res.jsonp({
     note: "This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.",
     meta: {
-      person_api_url: api_base_url + 'persons',
-      organization_api_url: api_base_url + 'organizations',
-      membership_api_url: api_base_url + 'memberships',
+      person_api_url: req.api_base_url + 'persons',
+      organization_api_url: req.api_base_url + 'organizations',
+      membership_api_url: req.api_base_url + 'memberships',
       image_proxy_url: base_url(req) + config.image_proxy.path,
     },
   });
@@ -39,7 +44,11 @@ api_01_app.get('/about', function (req, res, next) {
 
 api_01_app.use( function(req, res, next) {
     var db_name = config.MongoDB.popit_prefix + req.popit.instance_name();
-    popitApi({ databaseName: db_name })(req, res, next);
+    popitApi({
+      databaseName: db_name,
+      baseUrl: req.base_url,
+      apiBaseUrl: req.api_base_url
+    })(req, res, next);
 });
 
 // Load the various different API versions


### PR DESCRIPTION
This gives the API a simple way of knowing where the main application is hosted and where the API is mounted within it. This is used to generate links in the API output.

Part of #268 and #290.
