### PR TITLE
Replace links to components list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ You can use our [free hosting service](http://popit.mysociety.org/) instead of i
 
 You can contact at us at any of the following:
 
-  * The [Components mailing list](https://secure.mysociety.org/admin/lists/mailman/listinfo/components) for general discussion about PopIt and other similar components.
-  * The [PopIt-dev mailing list](https://secure.mysociety.org/admin/lists/mailman/listinfo/popit-dev) for development questions and discussion about PopIt.
+  * The [Poplus mailing list](https://groups.google.com/forum/#!forum/poplus) for general discussion about PopIt and other similar components.
   * Chat on the [#popit IRC channel](irc://irc.mysociety.org/popit) on `irc.mysociety.org`.
   * Read our [development diary](http://popit-dev.tumblr.com/) for frequent updates and musings.
   * Email us direct at [popit@mysociety.org](mailto:popit@mysociety.org).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,7 @@ PopIt is an easy-to-install web service for storing and sharing the names and ca
 
 You can contact at us at any of the following:
 
-  * The [Components mailing list](https://secure.mysociety.org/admin/lists/mailman/listinfo/components) for general discussion about PopIt and other similar components.
-  * The [PopIt-dev mailing list](https://secure.mysociety.org/admin/lists/mailman/listinfo/popit-dev) for development questions and discussion about PopIt.
+  * The [Poplus mailing list](https://groups.google.com/forum/#!forum/poplus) for general discussion about PopIt and other similar components.
   * Chat on the [#popit IRC channel](irc://irc.mysociety.org/popit) on `irc.mysociety.org`.
   * Read our [development diary](http://popit-dev.tumblr.com/) for frequent updates and musings.
   * Email us direct at [popit@mysociety.org](mailto:popit@mysociety.org).

--- a/hosting-app/views/html_footer.html
+++ b/hosting-app/views/html_footer.html
@@ -17,7 +17,7 @@
           <img src="/img/mysociety-logo.png" class="mysociety-logo">
         </a>
         
-        <p>This is the <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">α</a>lpha of <a href="<%= config.hosting_site_base_url %>">PopIt</a>, a new service for lowering the barrier to getting started with transparency projects. Please feel free to <!-- make a <a href="<%= config.hosting_site_base_url %>/instances/new">new instance</a>, and --> join <a href="https://secure.mysociety.org/admin/lists/mailman/listinfo/components">our mailing list</a> to let us know that you're interested in giving it a go.</p>
+        <p>This is the <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">α</a>lpha of <a href="<%= config.hosting_site_base_url %>">PopIt</a>, a new service for lowering the barrier to getting started with transparency projects. Please feel free to <!-- make a <a href="<%= config.hosting_site_base_url %>/instances/new">new instance</a>, and --> join <a href="https://groups.google.com/forum/#!forum/poplus">the poplus mailing list</a> to let us know that you're interested in giving it a go.</p>
 
         <p>The <a href="https://github.com/mysociety/popit">code is available on Github</a>, and we have a  <a href="http://popit-dev.tumblr.com/">dev blog</a> if you want frequent updates and musings on the project's development.</p>
 

--- a/instance-app/views/html_footer.html
+++ b/instance-app/views/html_footer.html
@@ -24,8 +24,8 @@
             that lowers the barrier to getting started with transparency projects. Development is ongoing and this is 
             <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">αlpha</a> code. Please feel free to 
             <!-- <a href="<%- config.hosting_site_base_url %>/instances/new">make your own instance</a>
-            , and --> join our 
-            <a href="https://secure.mysociety.org/admin/lists/mailman/listinfo/components">mailing list</a>
+            , and --> join the 
+            <a href="https://groups.google.com/forum/#!forum/poplus">poplus mailing list</a>
             to let us know that you're interested in giving it a go. 
           </p>
 

--- a/instance-app/views/info/data-import.html
+++ b/instance-app/views/info/data-import.html
@@ -44,7 +44,7 @@
 </p>
 
 <p>
-  API improvements is an ongoing task with several <a href="https://github.com/mysociety/popit/issues?labels=API&amp;milestone=&amp;page=1&amp;state=open">open issues</a>. If you have particular suggestions or questions please let us know on the <a href="https://secure.mysociety.org/admin/lists/mailman/listinfo/components"> components mailing list</a>.
+  API improvements is an ongoing task with several <a href="https://github.com/mysociety/popit/issues?labels=API&amp;milestone=&amp;page=1&amp;state=open">open issues</a>. If you have particular suggestions or questions please let us know on the <a href="https://groups.google.com/forum/#!forum/poplus">poplus mailing list</a>. 
 </p>
 
 <%= render('html_footer.html' )%>


### PR DESCRIPTION
Point at the Poplus mailing list rather than the old Components list (fixes #313)
