### PR TITLE
Make sure images are indexed after adding/removing

### DIFF
--- a/lib/apps/image.js
+++ b/lib/apps/image.js
@@ -6,7 +6,9 @@ var path          = require('path'),
     fs            = require('fs'),
     Error404      = require('../../lib/errors').Error404,
     check         = require('validator').check,
-    utils         = require('../utils');
+    utils         = require('../utils'),
+    config        = require('config'),
+    reIndex       = require('popit-api').reIndex;
 
 exports.get = function( req, res, next ) {
 
@@ -45,14 +47,23 @@ exports.delete = function( req, res, next ) {
         var idx = req.object.images.indexOf(image);
         if ( idx > -1 ) {
             req.object.images.splice(idx, 1);
-            req.object.save();
-            res.redirect( req.object.slug_url );
+            req.object.save(function(err) {
+                if (err) {
+                    return next(err);
+                }
+                reIndex(config.MongoDB.popit_prefix + req.popit.instance_name(), function(err) {
+                    if (err) {
+                        return next(err);
+                    }
+                    res.redirect( req.object.slug_url );
+                });
+            });
         }
     });
 
 };
 
-exports.upload_image = function( req, res ) {
+exports.upload_image = function( req, res, next ) {
 
     var url    = req.param('url');
     var upload = req.files.image || {};
@@ -72,9 +83,16 @@ exports.upload_image = function( req, res ) {
         var object = req.object;
         object.images.push(image);
         object.save(function(err) {
-            if (err) throw err;
-            // redirect to the object
-            res.redirect( object.slug_url );
+            if (err) {
+                return next(err);
+            }
+            reIndex(config.MongoDB.popit_prefix + req.popit.instance_name(), function(err) {
+                if (err) {
+                    return next(err);
+                }
+                // redirect to the object
+                res.redirect( object.slug_url );
+            });
         });
     }
 

--- a/tests/browser_based/photos.rb
+++ b/tests/browser_based/photos.rb
@@ -46,7 +46,7 @@ class PhotoTests < PopItWatirTestCase
       
       # upload a file
       @b.link(:text => '+ add a photograph').click
-      @b.file_field(:name => 'image').set( File.join( File.dirname(__FILE__), opts[:test_image]) )
+      @b.file_field(:name => 'image').set( File.expand_path("../#{opts[:test_image]}", __FILE__) )
       @b.input(:type => 'submit').click
       
       # check that the file is now shown on the page
@@ -66,5 +66,22 @@ class PhotoTests < PopItWatirTestCase
       assert_match opts[:placeholder_filename_regex], @b.ul(:class => 'photos').li.img.attribute_value('src')
     }
   end 
+
+  def test_adding_images_indexes_in_api
+    goto_instance 'test'
+    delete_instance_database
+    load_test_fixture
+    goto '/'
+    login_as :owner
+
+    goto '/persons/barack-obama'
+    @b.link(:text => '+ add a photograph').click
+    @b.text_field(:id, 'image_url').set('http://example.org/barak.jpg')
+    @b.input(:type => 'submit').click
+    assert @b.ul(:class => 'photos').li.img.present?
+
+    goto '/api/v0.1/search/persons?q=barack-obama'
+    assert @b.text.include?('http://example.org/barak.jpg')
+  end
 
 end


### PR DESCRIPTION
Because images are added to the object within popit rather than over the API we need to manually reindex the instance after adding or removing an image.

Ideally this code can eventually be removed in favour of just POSTing to the API directly, but in the meantime this seems like the simplest fix.

Closes #338 
