### PR TITLE
Use pluralised properties in the API metadata

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -25,9 +25,9 @@ api_01_app.get('/', function (req, res, next) {
   res.jsonp({
     note: "This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.",
     meta: {
-      person_api_url: req.api_base_url + '/persons',
-      organization_api_url: req.api_base_url + '/organizations',
-      membership_api_url: req.api_base_url + '/memberships',
+      persons_api_url: req.api_base_url + '/persons',
+      organizations_api_url: req.api_base_url + '/organizations',
+      memberships_api_url: req.api_base_url + '/memberships',
       image_proxy_url: base_url(req) + config.image_proxy.path,
     },
   });


### PR DESCRIPTION
This is to be consistent with the urls that they refer to, which are pluralised. It should also make popit-python work properly again.

Closes #343 
