### PR TITLE
Fix issue where /about fields default to false

### DIFF
--- a/lib/schemas/setting.js
+++ b/lib/schemas/setting.js
@@ -12,7 +12,7 @@ module.exports = new Schema({
         required:  true,        
     },
     value: {
-        type:      String,
+        type: mongoose.Schema.Types.Mixed,
         required:  true,        
     }
 }, { strict: true } );


### PR DESCRIPTION
The issue was the all fields were getting cast to String values. When
the page was saved the correct settings were saved in memory, but a
string representation of the settings were saved to the database. So the
problem didn't become apparent until the process was restarted and the
settings were loaded from the database again.

This (tiny) pull request will prevent this from happening in the future, but we still need to fix existing instances that have this problem. I'm not sure how many there are but perhaps it's easiest just to go through manually?

Fixes https://github.com/mysociety/popit/issues/370
