### PR TITLE
correct image deletion post url

### DIFF
--- a/instance-app/views/organization/view.html
+++ b/instance-app/views/organization/view.html
@@ -61,11 +61,11 @@
               <% //- TODO - proxy will need changes to allow us to proxy remote images %>
               <img src="<%- image.url %>"  width="280" />
             <% } else { %>
-              <img src="<%- image_proxy("/organizations/images/" + image.id + '/' + organization.id, "", 280) %>" />
+              <img src="<%- image_proxy(image_url( 'organization', organization, image ) , "", 280) %>" />
             <% } %>
 
             <p class="photo-actions edit-mode">
-              <a class="delete-photo btn btn-default btn-sm" data-image-url="<%- organization.url %>/images/<%- image.id %>">
+            <a class="delete-photo btn btn-default btn-sm" data-image-url="<%- image_url( 'organization', organization, image ) %>">
                 <span class="glyphicon glyphicon-trash glyphicon-space-after"></span>
                 Delete this photograph
               </a>

--- a/instance-app/views/person/view.html
+++ b/instance-app/views/person/view.html
@@ -53,11 +53,11 @@
               <% // TODO - proxy will need changes to allow us to proxy remote images %>
               <img src="<%- image.url %>" width="280" />
             <% } else { %>
-              <img src="<%- image_proxy("/persons/images/" + image.id + '/' + person.id, "", 280) %>" />
+              <img src="<%- image_proxy(image_url('person', person, image), "", 280) %>" />
             <% } %>
 
             <p class="photo-actions edit-mode">
-              <a class="delete-photo btn btn-default btn-sm" data-image-url="<%- person.url %>/images/<%- image.id %>">
+              <a class="delete-photo btn btn-default btn-sm" data-image-url="<%- image_url( 'person', person, image ) %>">
                 <span class="glyphicon glyphicon-trash glyphicon-space-after"></span>
                 Delete this photograph
               </a>

--- a/lib/apps/generic_document.js
+++ b/lib/apps/generic_document.js
@@ -31,6 +31,12 @@ module.exports = function (opts) {
     image_proxy: utils.image_proxy_helper
   });
 
+  app.locals({
+    image_url: function(type, object, image) {
+      return '/' + type + 's/images/' + image.id + '/' + object.id;
+    }
+  });
+
   app.get('/', function (req,res,next) {
     var search = req.param('name');
     if (search) {


### PR DESCRIPTION
the POST action URL used on the image deletion form was incorrect
which meant images could not be deleted. Fix this by adding an image url
generating function rather than coding them by hand in the template.

Fixes #407 and #412
