### PR TITLE
prevent errors when listing broken memberships

### DIFF
--- a/instance-app/views/membership/list-item.html
+++ b/instance-app/views/membership/list-item.html
@@ -1,4 +1,5 @@
 <li>
+<% if ( membership.organization_id !== null ) { %>
   <div class="view-mode">
     <% if (membership.post_id) { %> <%- membership.post_id.label %>: <% } %>
     <% if (membership.label) { %> <%- membership.label %> <% } %>
@@ -37,5 +38,5 @@
       <span class="text-muted">(to <%- membership.end_date %>)</span>
     <% } %>
   </div>
+<% } %>
 </li>
-


### PR DESCRIPTION
If the other side of the membership has been deleted then skip over
listing the details to prevent errors.
we need to leave the li in place as otherwise the code that attaches
edit events to this, which currently doesn't know about the contents of
memberships, relies on them being there to assign id data correctly.

Fixes #405
