### PR TITLE
Include instance name in confirmation email

### DIFF
--- a/hosting-app/views/emails/new_instance.txt
+++ b/hosting-app/views/emails/new_instance.txt
@@ -1,7 +1,7 @@
 Hello,
 
-A new PopIt instance will be created for you after you confirm your email
-address by visiting the link below:
+A new PopIt instance called {{ instance.slug }} will be created for you after
+you confirm your email address by visiting the link below:
 
   http://{{ host }}/instances/{{ instance.slug }}/confirm/{{ token }}
 


### PR DESCRIPTION
Add the slug name to the text of the email as well as including it in
the confirmation URL.

Fixes #455
