### PR TITLE
Add a friendlier forgotten password screen

### DIFF
--- a/instance-app/views/forgotten-password.html
+++ b/instance-app/views/forgotten-password.html
@@ -1,0 +1,22 @@
+<%= render('html_head.html', {
+  title:       'Forgotten password',
+  description: '',
+}) %>
+
+<div class="container">
+  <h1>Forgotten password</h1>
+
+  <p>
+    To find your PopIt password check your email - we sent to your password to
+    you when your PopIt instance was created.
+  </p>
+
+  <p>
+    Search for an email with the subject "New instance confirmation" in your
+    email history.
+  </p>
+
+  <p><a href="/login">Back to Log in</a></p>
+</div>
+
+<%= render('html_footer.html') %>

--- a/instance-app/views/login.html
+++ b/instance-app/views/login.html
@@ -42,7 +42,7 @@
       </p>
 
       <p class="form-group">
-        <a href="https://github.com/mysociety/popit/issues/17" class="pull-right">Forgotten?</a>
+        <a href="/forgotten-password" class="pull-right">Forgotten?</a>
         <label for="password" class="control-label">Password:</label>
         <input id="password" type="password" name="password" class="form-control">
       </p>

--- a/lib/apps/auth.js
+++ b/lib/apps/auth.js
@@ -111,7 +111,9 @@ app.get('/logout', function (req,res,next) {
   });
 });
 
-
+app.get('/forgotten-password', function(req, res) {
+  res.render('forgotten-password.html');
+});
 
 module.exports.app = app;
 


### PR DESCRIPTION
Rather than linking to a GitHub ticket (which won't help the user when they've forgotten their password), remind the user that we emailed their password to them when they created their PopIt instance.

Fixed https://github.com/mysociety/popit/issues/507
