### PR TITLE
set edit interface tab to view tab when click edit button

### DIFF
--- a/public/js/instance-admin/views/edit.js
+++ b/public/js/instance-admin/views/edit.js
@@ -21,6 +21,7 @@ define(['jquery', 'Backbone', 'underscore'], function($, Backbone, _) {
       $('.view-mode').hide();
       $('.edit-mode').show();
       $('article.entity').hide();
+      $('.edit-form .entity-details').easytabs('select', window.location.hash);
       $('.edit-form').show();
       $('.entity').addClass('editing');
 


### PR DESCRIPTION
use the window.location.hash to work out which tab is currently selected
and make sure that tab is selected in the edit interface before
displaying it.

Fixes #522
