### PR TITLE
Always match active tab when switching to edit view

### DIFF
--- a/public/js/instance-admin/views/edit.js
+++ b/public/js/instance-admin/views/edit.js
@@ -21,7 +21,10 @@ define(['jquery', 'Backbone', 'underscore'], function($, Backbone, _) {
       $('.view-mode').hide();
       $('.edit-mode').show();
       $('article.entity').hide();
-      $('.edit-form .entity-details').easytabs('select', window.location.hash);
+      var tab = $('.person-view .entity-details li.active');
+      if ( tab ) {
+        $('.edit-form .entity-details').easytabs('select', tab.children('a').attr('href'));
+      }
       $('.edit-form').show();
       $('.entity').addClass('editing');
 


### PR DESCRIPTION
If the tab on the view section has been programatically set then there
isn't a location hash to the existing code doesn't work. This code
resolves this by working out which tab is selected via classes.

Fixes #522
