### PR TITLE
Add the posts API endpoint to the root of the API

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -28,6 +28,7 @@ api_01_app.get('/', function (req, res, next) {
       persons_api_url: req.api_base_url + '/persons',
       organizations_api_url: req.api_base_url + '/organizations',
       memberships_api_url: req.api_base_url + '/memberships',
+      posts_api_url: req.api_base_url + '/posts',
       image_proxy_url: base_url(req) + config.image_proxy.path,
     },
   });

--- a/test/api-app.js
+++ b/test/api-app.js
@@ -14,6 +14,7 @@ describe("API v0.1", function() {
         persons_api_url: "http://test.popit.example.org/api/v0.1/persons",
         organizations_api_url: "http://test.popit.example.org/api/v0.1/organizations",
         memberships_api_url: "http://test.popit.example.org/api/v0.1/memberships",
+        posts_api_url: "http://test.popit.example.org/api/v0.1/posts",
         image_proxy_url: "http://test.popit.example.org/image-proxy/"
       }
     }, done)


### PR DESCRIPTION
The API now supports distinct posts and memberships, as in the Popolo
specification, but language bindings that explore the top level API to
discover available collections (e.g. popit-python) previously
wouldn't have discovered the posts collection.  This commit adds that
link.

Fixes #545 
