### PR TITLE
Handle invalid URL error in image upload

### DIFF
--- a/instance-app/views/image/upload_image.html
+++ b/instance-app/views/image/upload_image.html
@@ -17,7 +17,10 @@
 
   <p class="form-group">
     <label for="image_url">Or specify URL</label>
-    <input class="form-control" type="text" id="image_url" name="url" />
+    <input class="form-control" type="text" id="image_url" name="url" value="<%= url %>"/>
+    <% if ( errors && errors.image_url ) { %>
+    <strong><%= errors.image_url %></strong>
+    <% } %>
 
     <%
       //- if opts.form_help_text

--- a/lib/apps/image.js
+++ b/lib/apps/image.js
@@ -69,6 +69,8 @@ exports.upload_image = function( req, res, next ) {
 
     var url    = req.param('url');
     var upload = req.files.image || {};
+    res.locals.url = '';
+    res.locals.errors = null;
 
     // Neither, or both provided. TODO relevant error message
     if ( (upload.size && url) || !(upload.size || url) ) {
@@ -76,7 +78,13 @@ exports.upload_image = function( req, res, next ) {
     }
 
     if ( url ) {
-        check(url).isUrl();
+        try {
+            check(url).isUrl();
+        } catch(e) {
+            res.locals.url = url;
+            res.locals.errors = { image_url: e.message };
+            return res.render( 'image/upload_image.html' );
+        }
     }
 
     // FIXME - don't trust that we have an image


### PR DESCRIPTION
The image url validation code throws an exception on invalid URLs which
we were not catching. This now catches it and displays an error message.

Fixes #558
