### PR TITLE
allow memberships to be deleted and added at same time

### DIFF
--- a/lib/apps/person.js
+++ b/lib/apps/person.js
@@ -60,9 +60,17 @@ module.exports = function () {
     delete req.body.memberships;
 
     // we have to do this here otherwise it's impossible to delete
-    // a single membership
+    // a single membership. The map reduces it to a list of ids, the
+    // compact removed the undefined ids of any new memberships. The
+    // second step is required otherwise the find and remove doesn't
+    // work if there are new memberships
     var Membership = req.db.model('Membership');
-    var membership_ids = _.map(memberships, function(membership) { return membership.id; });
+    var membership_ids =
+      _.chain(memberships)
+       .map( function(membership) { return membership.id; })
+       .compact()
+       .value();
+
     Membership
       .find( { 'person_id': req.param('id') } )
       .where( '_id' ).nin( membership_ids )


### PR DESCRIPTION
If you added a new membership to a person then the list of ids passed to
the nin query would include an undefinded entry. As all the membership
id of a person were not undefined this would result in the query
never selecting any documents. We now filter out any undefineds from the
id list to prevent this.

Fixes #600
