### PR TITLE
remove entity-save-changes class from person submit button

### DIFF
--- a/instance-app/views/person/form.html
+++ b/instance-app/views/person/form.html
@@ -177,7 +177,7 @@
   </div>
 
   <div class="btn-group">
-    <button type="submit" class="btn btn-success entity-save-changes"><span class="glyphicon glyphicon-ok glyphicon-space-after"></span> Save changes</button>
+    <button type="submit" class="btn btn-success"><span class="glyphicon glyphicon-ok glyphicon-space-after"></span> Save changes</button>
   </div>
 
 </form>


### PR DESCRIPTION
the enter-to-save augmenter triggers a click on anything with a class of
entity-save-changes when you hit enter in an input box. If the submit
button has this class then it means there are two items with that class
on the page which means that sometimes the form is submitted twice. This
can cause multiple memberships to be added.

Fixes #599
