### PR TITLE
only save organisation when editing a person if new

### DIFF
--- a/lib/apps/person.js
+++ b/lib/apps/person.js
@@ -83,6 +83,20 @@ module.exports = function () {
 
     var Organization = req.db.model('Organization');
 
+    var updateMembership = function(membership, done) {
+      Membership.findById(membership.id, function(err, doc) {
+        if (err) {
+          return done(err);
+        }
+        if (!doc) {
+          var objectId = new mongoose.Types.ObjectId();
+          doc = new Membership({_id: objectId.toHexString()});
+        }
+        doc.set(membership);
+        doc.save(done);
+      });
+    }
+
     async.forEachSeries(memberships, function(membership, done) {
       Organization.findById(membership.organization_id, function(err, organization) {
         if (err) {
@@ -93,25 +107,18 @@ module.exports = function () {
           var objectId = new mongoose.Types.ObjectId();
           organization = new Organization({_id: objectId.toHexString(), name: membership.organization_name});
           membership.organization_id = organization._id;
-        }
-        delete membership.organization_name;
-        organization.save(function(err) {
-          if (err) {
-            return done(err);
-          }
-
-          Membership.findById(membership.id, function(err, doc) {
+          delete membership.organization_name;
+          organization.save(function(err) {
             if (err) {
               return done(err);
             }
-            if (!doc) {
-              var objectId = new mongoose.Types.ObjectId();
-              doc = new Membership({_id: objectId.toHexString()});
-            }
-            doc.set(membership);
-            doc.save(done);
+
+            updateMembership(membership, done);
           });
-        });
+        } else {
+          delete membership.organization_name;
+          updateMembership(membership, done);
+        }
 
       });
     }, next);


### PR DESCRIPTION
This then skips the post save action in the API that reindexes all the
documents in the membership which in the case of organisations that have
lots of assocaited memberships is extremely resource intensive and
causes the server to fall over
