### PR TITLE
Add examples for contact details fields

### DIFF
--- a/instance-app/views/contact/edit.html
+++ b/instance-app/views/contact/edit.html
@@ -1,10 +1,10 @@
-<label for="contact_label_<%= i %>">Label</label>
+<label for="contact_label_<%= i %>">Label (e.g. 'Office Address', 'Twitter Account', 'Work Phone Number', etc.)</label>
 <input type="text" id="contact_label_<%= i %>" name="contact_details[<%= i %>][label]" value="<%= contact.label || '' %>">
 
-<label for="contact_type_<%= i %>">Type</label>
+<label for="contact_type_<%= i %>">Type (e.g. 'twitter', 'facebook', 'cell', 'address', 'fax', etc.)</label>
 <input type="text" id="contact_type_<%= i %>" name="contact_details[<%= i %>][type]" value="<%= contact.type || '' %>">
 
-<label for="contact_value_<%= i %>">Value</label>
+<label for="contact_value_<%= i %>">Value (e.g. a phone number, a Twitter or Facebook username, an address, etc.)</label>
 <input type="text" id="contact_value_<%= i %>" name="contact_details[<%= i %>][value]" value="<%= contact.value || '' %>">
 
 <label for="contact_note_<%= i %>">Note</label>


### PR DESCRIPTION
It's completely unclear to most users what should go in the 'Label',
'Value', 'Type' and 'Note' fields should be when adding or editing a
contact detail for a person. There's an argument that we should think
more broadly about how to redesign the entry of these kinds of details,
but in the interim this change (adding examples for three out of four
of those fields) at least provides some help for users until we have
time to do something more involved.  I left out the 'Note' field since
it's unclear to me at the moment how it should be used - I assumed this
was for free-form text for any useful notes about that contact detail,
but the example in the Popolo spec ("e.g. for grouping contact details
by physical location" [1]) makes wonder about that.

 [1] http://popoloproject.com/specs/contact-detail.html

This is an interim fix for #525.
