### PR TITLE
replace-database: it's safer to use second granularity in the timestamp

### DIFF
--- a/bin/replace-database
+++ b/bin/replace-database
@@ -9,7 +9,7 @@
 set -ex
 
 COLLECTIONS=('organizations' 'persons' 'memberships')
-DATE=$(date +%Y%m%d)
+DATE=$(date +%Y%m%d%H%M%S)
 
 if [ "$#" != "4" ]
 then


### PR DESCRIPTION
It's very common for me to have to run replace-database more than once a
day, but extremely unlikely that one would run it twice in a second for
the instance, so I think it's safer to have the timestamp to a
granularity of seconds rather than days.
