### PR TITLE
Update the service name mongodb -> mongod to match package upgrade

### DIFF
--- a/config/popit-daemon-debian.ugly
+++ b/config/popit-daemon-debian.ugly
@@ -4,8 +4,8 @@
 
 ### BEGIN INIT INFO
 # Provides:          !!(*= $daemon_name *)!!
-# Required-Start:    $network mongodb
-# Required-Stop:     $network mongodb
+# Required-Start:    $network mongod
+# Required-Stop:     $network mongod
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Run PopIt service.


### PR DESCRIPTION
We recently upgraded our version of MongoDB to the one provided by 10gen
rather than the Debian packaged version. One of the changes in these new
packages was that the service name in the Provides: line of MongoDB has
changed from 'mongodb' to 'mongod'. This means that the call to
update-rc.d for the PopIt sysvinit was emitting these errors:

  update-rc.d: using dependency based boot sequencing
  insserv: Service mongodb has to be enabled to start service popit-staging
  insserv: exiting now!
  update-rc.d: error: insserv rejected the script header

Before merging this we should check whether any of the other known
redeployers of PopIt are using this template for the sysvinit script.
