### PR TITLE
Override public_dir in testing environment config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - export WATIR_BROWSER=firefox
-  # this is to point connect-assets at the correct directory for css
-  - sed -i -e 's/public-production/public/' config/default.js
   - make css
 
 notifications:

--- a/config/testing.js
+++ b/config/testing.js
@@ -1,5 +1,8 @@
 module.exports = {
 
+    // Don't use minified assets - makes dev easier as no js rebuild required
+    public_dir: 'public',
+
     // show the worning on the web pages
     show_dev_site_warning: true,
 


### PR DESCRIPTION
This prevents the tests from failing locally when there's no `public-production` directory present. Which means they should run "out-of-the-box", e.g. after doing a fresh `vagrant up`.
