### PR TITLE
Load extra vagrant configuration from another file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 POPIT_VAGRANT_PORT = ENV['POPIT_VAGRANT_PORT'] || 3000
-POPIT_VAGRANT_NFS = ENV['POPIT_VAGRANT_NFS'] == '1'
 POPIT_VAGRANT_MEMORY = ENV['POPIT_VAGRANT_MEMORY'] || 1024
+POPIT_VAGRANT_EXTRAS = ENV['POPIT_VAGRANT_EXTRAS']
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
@@ -15,11 +15,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :forwarded_port, guest: 3000, host: POPIT_VAGRANT_PORT
 
-  if POPIT_VAGRANT_NFS
-    config.vm.network "private_network", ip: "192.168.33.10"
-    config.vm.synced_folder ".", "/vagrant", type: "nfs"
-  end
-
   config.vm.provider :virtualbox do |v|
     # assign memory and CPU as needed
     v.customize ["modifyvm", :id, "--memory", POPIT_VAGRANT_MEMORY]
@@ -27,4 +22,11 @@ Vagrant.configure("2") do |config|
 
   # Provision using the shell provisioner
   config.vm.provision :shell, :path => "config/provision.sh"
+end
+
+# If you want to add additional configuration options then create a file
+# containing another 'Vagrant.configure' block and point the
+# POPIT_VAGRANT_EXTRAS environment variable to it.
+if POPIT_VAGRANT_EXTRAS
+  require POPIT_VAGRANT_EXTRAS
 end


### PR DESCRIPTION
Allow adding to the vagrant configuration with another file rather than
having lots of conditional code based on environment variables in the
`Vagrantfile`.

This loads the file specified in the POPIT_VAGRANT_EXTRAS environment
variable, which can contain another `Vagrant.configure` block which will add
to/override settings from the main `Vagrantfile`.

See https://docs.vagrantup.com/v2/vagrantfile/index.html for more
information (under the "LOAD ORDER AND MERGING" heading).
