### PR TITLE
add alternative image URL to match API schema

### DIFF
--- a/lib/apps/generic_document.js
+++ b/lib/apps/generic_document.js
@@ -136,6 +136,7 @@ module.exports = function (opts) {
   
   app.get(  '/:id(*)/images/upload', user.can('edit instance'), image.upload_image );
   app.post( '/:id(*)/images/upload', user.can('edit instance'), image.upload_image );
+  app.get(  '/:id/image/:image_spec', image.get );
   app.get(  '/images/:image_spec/:id(*)', image.get );
   app.post( '/images/:image_spec/:id(*)/delete', user.can('edit instance'), image.delete );
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1176,8 +1176,8 @@
     },
     "popit-api": {
       "version": "0.0.14",
-      "from": "popit-api@git://github.com/mysociety/popit-api.git#4417bd8151aafda3978dd040bccdf97b57a5e051",
-      "resolved": "git://github.com/mysociety/popit-api.git#4417bd8151aafda3978dd040bccdf97b57a5e051",
+      "from": "git://github.com/mysociety/popit-api.git#master",
+      "resolved": "git://github.com/mysociety/popit-api.git#a38c17ba4b6eab3fca519523b6a58419718abc30",
       "dependencies": {
         "JSV": {
           "version": "4.0.2",
@@ -1359,6 +1359,11 @@
               }
             }
           }
+        },
+        "mpath": {
+          "version": "0.2.1",
+          "from": "mpath@~0.2.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz"
         },
         "underscore": {
           "version": "1.4.4",


### PR DESCRIPTION
The API uses a different URL scheme to identify images so add an
alternative one for the UI so the two can match up.

For mysociety/popit-api#84
