### PR TITLE
Stop membership view from 500ing

### DIFF
--- a/instance-app/views/membership/view.html
+++ b/instance-app/views/membership/view.html
@@ -33,14 +33,6 @@
   <p>Start Date: <%- membership.start_date || 'Unknown' %></p>
   <p>End Date:   <%- membership.end_date   || 'Unknown' %></p>
 
-  <section class="to_be_added">
-    <p>
-      There is a
-      <a href="https://github.com/mysociety/popit/issues/183">github ticket</a>
-      to put more details on this page.
-    </p>
-  </section>
-  
   <section class="raw-data">
     <h2>Raw data</h2>
     <p>


### PR DESCRIPTION
Stop membership view page from 500-ing when missing an organization or person. Also did a tiny bit of tidying just so the page doesn't look completely forgotten.

Fixes #657 
