### PR TITLE
Fix issues with deleting memberships

### DIFF
--- a/lib/apps/person.js
+++ b/lib/apps/person.js
@@ -74,8 +74,14 @@ module.exports = function () {
     Membership
       .find( { 'person_id': req.param('id') } )
       .where( '_id' ).nin( membership_ids )
-      .remove()
-      .exec();
+      .exec( function( err, memberships ) {
+        if ( err ) {
+          next(err);
+        }
+        async.forEachSeries(memberships, function(membership, done) {
+          membership.remove(done);
+        });
+      });
 
     if (!memberships) {
       return next();


### PR DESCRIPTION
Not sure why this has stopped working but if you use .nin or $nin in a
where and then tack on a remove, or use them in a remove then it
produces an error about there being a $ in the key. To fix this do the
where then explicitely remove all the returned memberships.

Fixes #666
