### PR TITLE
replace-database: You no longer need to supply the old DB name

### DIFF
--- a/bin/replace-database
+++ b/bin/replace-database
@@ -104,7 +104,7 @@ MONGO_NEW_DB_NAME="$(echo "$MONGO_DB_NAME" | sed 's/_[0-9]\{14\}$//')_$DATE"
 MISSING_FILES=""
 for COLLECTION in "${COLLECTIONS[@]}"
 do
-    FILENAME="$DUMP_ROOT$COLLECTION.json"
+    FILENAME="$DUMP_ROOT$COLLECTION.dump"
     if ! [ -e "$FILENAME" ]
     then
         MISSING_FILES="$FILENAME $MISSING_FILES"
@@ -124,7 +124,7 @@ do
     mongoimport \
         --db "$MONGO_NEW_DB_NAME" \
         --collection "$COLLECTION" \
-        "$DUMP_ROOT$COLLECTION.json"
+        "$DUMP_ROOT$COLLECTION.dump"
 done
 
 # now copy the settings data across which has instance name etc


### PR DESCRIPTION
Previously you had to specify the old Mongo database name; this would
either be the same as the slug (if replace-database had never been used
on this instance before) or the instance slug suffixed with a datetime
(if replace-database had been used before). This commit changes that so
that you don't need to specify the old DB name - it's inferred from the
instance slug regardless of which of those situations the instance is
in.

Fixes #663
