### PR TITLE
Add disclaimer to bottom of pages displaying data

### DIFF
--- a/instance-app/app.js
+++ b/instance-app/app.js
@@ -39,6 +39,7 @@ app.use(popitApiStorageSelector({
   databasePrefix: config.MongoDB.popit_prefix
 }));
 
+app.use( require('../lib/middleware/disclaimer') );
 app.use( require('../lib/apps/auth').middleware );
 app.use( require('../lib/apps/auth').app );
 app.use(accept);

--- a/instance-app/views/disclaimer.html
+++ b/instance-app/views/disclaimer.html
@@ -1,0 +1,7 @@
+<div class="disclaimer">
+<% if ( disclaimer_text ) { %>
+<%= disclaimer_text %>
+<% } else { %>
+We believe this information to be accurate but if you have any queries or corrections please use the contact address on the About page.
+<% } %>
+</div>

--- a/instance-app/views/organization/view.html
+++ b/instance-app/views/organization/view.html
@@ -243,6 +243,8 @@
         <%= render( 'identifier/list.html', { identifiers: organization.identifiers } ) %>
       </div>
     </div>
+
+    <%= render('disclaimer.html') %>
   </div>
 
   <section class="custom-data" style="display: none">

--- a/instance-app/views/person/view.html
+++ b/instance-app/views/person/view.html
@@ -223,6 +223,7 @@
       </div>
     </div>
 
+    <%= render('disclaimer.html' )%>
   </div>
 
   <section class="custom-data" style="display: none">

--- a/instance-app/views/post/view.html
+++ b/instance-app/views/post/view.html
@@ -71,6 +71,8 @@
         </ul>
       </div>
     </div>
+
+    <%= render('disclaimer.html') %>
   </div>
 
 </article>

--- a/lib/apps/about.js
+++ b/lib/apps/about.js
@@ -22,6 +22,7 @@ module.exports = function () {
     "contact_name":       { type: "textbox",  label: "Contact Name"                    },
     "contact_email":      { type: "textbox",  label: "Contact Email"                   },
     "contact_phone":      { type: "textbox",  label: "Contact Phone"                   },
+    "disclaimer":         { type: "textarea", label: "Override disclaimer"             },
   };
   
   // create an array of the field names

--- a/lib/middleware/disclaimer.js
+++ b/lib/middleware/disclaimer.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = function configMiddleware(req, res, next) {
+  res.locals.disclaimer_text = req.popit.setting('disclaimer');
+  next();
+};

--- a/public/sass/_people-and-organizations.scss
+++ b/public/sass/_people-and-organizations.scss
@@ -215,6 +215,11 @@ $entity-photo-sidebar-width: 285px;
       padding-left: 12px; // to line up with text inside .form-controls
     }
   }
+
+  .disclaimer {
+    font-size: 10px;
+    text-align: right;
+  }
 }
 
 .entity-header {


### PR DESCRIPTION
Adds a disclaimer to the bottom of the Person, Organization and Post
pages, plus the ability to override this on the About page.

This still possibly needs some design and wording changes.

Fixes #699