### PR TITLE
implement API versioning

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -85,6 +85,7 @@ api_02_app.use( function(req, res, next) {
 // Load the various different API versions
 app.use( '/v0.1', api_01_app );
 app.use( '/v0.2', api_02_app );
+app.use( '/current', api_02_app );
 
 app.get('/', function (req, res) {
   res.render('api/index.html');

--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -5,6 +5,7 @@ var express = require('../../express-inherit'),
     about = require('../about'),
     config = require('config'),
     user = require('../../authorization'),
+    popitApi01 = require('popit-api-0.1'),
     popitApi = require('popit-api');
 
 var app = module.exports = express();
@@ -12,53 +13,78 @@ var app = module.exports = express();
 // Pretty print json in production as well as development
 app.set('json spaces', 2);
 
-var api_01_app = express();
-// Ensure that these methods all require a user.
-api_01_app.post( '*', apiRequireUser, user.can('edit instance') );
-api_01_app.put(  '*', apiRequireUser, user.can('edit instance') );
-api_01_app.delete(  '*', apiRequireUser, user.can('edit instance') );
+function generateApiBaseUrl(req, version) {
+  return req.base_url('/api/v' + version);
+}
 
-app.use(function(req, res, next) {
-  req.baseUrl = req.base_url();
-  req.apiBaseUrl = req.base_url('/api/v0.1');
-  next();
-});
+function setupApp(api_ver, version) {
 
-api_01_app.get('/', function (req, res, next) {
-  res.jsonp({
-    note: "This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.",
-    meta: {
-      persons_api_url: req.apiBaseUrl + '/persons',
-      organizations_api_url: req.apiBaseUrl + '/organizations',
-      memberships_api_url: req.apiBaseUrl + '/memberships',
-      posts_api_url: req.apiBaseUrl + '/posts',
-      image_proxy_url: req.baseUrl + config.image_proxy.path,
-    },
+  // Ensure that these methods all require a user.
+  api_ver.post( '*', apiRequireUser, user.can('edit instance') );
+  api_ver.put(  '*', apiRequireUser, user.can('edit instance') );
+  api_ver.delete(  '*', apiRequireUser, user.can('edit instance') );
+
+  app.use(function(req, res, next) {
+    req.baseUrl = req.base_url();
+    next();
   });
-});
 
-api_01_app.get('/about', function (req, res, next) {
-  var about_object = about();
-  var about_info = about_object.load_about_data(req, function(result){
+  api_ver.get('/', function (req, res, next) {
+    var apiBaseUrl = generateApiBaseUrl(req, version);
     res.jsonp({
-      'result' : result,
+      note: "This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.",
+      meta: {
+        persons_api_url: apiBaseUrl + '/persons',
+        organizations_api_url: apiBaseUrl + '/organizations',
+        memberships_api_url: apiBaseUrl + '/memberships',
+        posts_api_url: apiBaseUrl + '/posts',
+        image_proxy_url: req.baseUrl + config.image_proxy.path,
+      },
     });
   });
-});
+
+  api_ver.get('/about', function (req, res, next) {
+    var about_object = about();
+    var about_info = about_object.load_about_data(req, function(result){
+      res.jsonp({
+        'result' : result,
+      });
+    });
+  });
+
+  return api_ver;
+}
+
+var api_01_app = express();
+api_01_app = setupApp(api_01_app, '0.1');
+
+var api_02_app = express();
+api_02_app = setupApp(api_02_app, '0.2');
 
 api_01_app.use( function(req, res, next) {
     var db_name = config.MongoDB.popit_prefix + req.popit.dbname();
-    popitApi({
+    popitApi01({
       databaseName: db_name,
       baseUrl: req.baseUrl,
-      apiBaseUrl: req.apiBaseUrl,
+      apiBaseUrl: req.base_url('/api/v0.1'),
       proxyBaseUrl: req.base_url(config.image_proxy.path),
       defaultLanguage: req.popit.setting('language'),
     })(req, res, next);
 });
 
+api_02_app.use( function(req, res, next) {
+    var db_name = config.MongoDB.popit_prefix + req.popit.dbname();
+    popitApi({
+      databaseName: db_name,
+      baseUrl: req.baseUrl,
+      apiBaseUrl: req.base_url('/api/v0.2'),
+      proxyBaseUrl: req.base_url(config.image_proxy.path),
+      defaultLanguage: req.popit.setting('language'),
+    })(req, res, next);
+});
 // Load the various different API versions
 app.use( '/v0.1', api_01_app );
+app.use( '/v0.2', api_02_app );
 
 app.get('/', function (req, res) {
   res.render('api/index.html');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1523,6 +1523,197 @@
         }
       }
     },
+    "popit-api-0.1": {
+      "version": "0.0.14",
+      "from": "git://github.com/mysociety/popit-api.git#v0.1",
+      "resolved": "git://github.com/mysociety/popit-api.git#fccb5b26633556c2f097c3329762f5dfbfecc515",
+      "dependencies": {
+        "JSV": {
+          "version": "4.0.2",
+          "from": "JSV@~4.0.2",
+          "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@~0.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "doublemetaphone": {
+          "version": "0.1.2",
+          "from": "doublemetaphone@~0.1.2",
+          "resolved": "https://registry.npmjs.org/doublemetaphone/-/doublemetaphone-0.1.2.tgz"
+        },
+        "elasticsearch": {
+          "version": "1.5.14",
+          "from": "elasticsearch@~1.5.1",
+          "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-1.5.14.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@~0.4",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@0.5.2",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@~2.4",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "when": {
+              "version": "2.8.0",
+              "from": "when@~2.8",
+              "resolved": "https://registry.npmjs.org/when/-/when-2.8.0.tgz"
+            }
+          }
+        },
+        "mongoose": {
+          "version": "3.8.21",
+          "from": "mongoose@~3.8.5",
+          "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.8.21.tgz",
+          "dependencies": {
+            "mongodb": {
+              "version": "1.4.12",
+              "from": "mongodb@1.4.12",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.12.tgz",
+              "dependencies": {
+                "bson": {
+                  "version": "0.2.16",
+                  "from": "bson@~0.2",
+                  "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.16.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.3.0",
+                      "from": "nan@1.3.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+                    }
+                  }
+                },
+                "kerberos": {
+                  "version": "0.0.4",
+                  "from": "kerberos@0.0.4",
+                  "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.4.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@latest",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hooks": {
+              "version": "0.2.1",
+              "from": "hooks@0.2.1",
+              "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz"
+            },
+            "ms": {
+              "version": "0.1.0",
+              "from": "ms@0.1.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz"
+            },
+            "sliced": {
+              "version": "0.0.5",
+              "from": "sliced@0.0.5",
+              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+            },
+            "muri": {
+              "version": "0.3.1",
+              "from": "muri@0.3.1",
+              "resolved": "https://registry.npmjs.org/muri/-/muri-0.3.1.tgz"
+            },
+            "mpromise": {
+              "version": "0.4.3",
+              "from": "mpromise@0.4.3",
+              "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.4.3.tgz"
+            },
+            "mpath": {
+              "version": "0.1.1",
+              "from": "mpath@0.1.1",
+              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
+            },
+            "regexp-clone": {
+              "version": "0.0.1",
+              "from": "regexp-clone@0.0.1",
+              "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+            },
+            "mquery": {
+              "version": "0.8.0",
+              "from": "mquery@0.8.0",
+              "resolved": "https://registry.npmjs.org/mquery/-/mquery-0.8.0.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mpath": {
+          "version": "0.2.1",
+          "from": "mpath@~0.2.1",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz"
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@~1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "from": "underscore.string@~2.3.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+        },
+        "unorm": {
+          "version": "1.3.3",
+          "from": "unorm@~1.3.1",
+          "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.3.3.tgz"
+        }
+      }
+    },
     "pow-mongodb-fixtures": {
       "version": "0.8.1",
       "from": "https://registry.npmjs.org/pow-mongodb-fixtures/-/pow-mongodb-fixtures-0.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "passport-local": ">= 1.0.0",
     "passport-local-mongoose": ">= 0.3.0",
     "passport-localapikey-update": "^0.4.2",
+    "popit-api-0.1": "git://github.com/mysociety/popit-api.git#v0.1",
     "popit-api": "git://github.com/mysociety/popit-api.git#master",
     "pow-mongodb-fixtures": ">= 0.6.0",
     "regexp-quote": ">= 0.0.0",


### PR DESCRIPTION
This works by having a v0.1 branch of the api module with a different
name in package.json which we then install. We need to do this as npm
uses the name of the module as the install path under node_modules and
there isn't a way to override this.

There's also code to map the correct module to the relevant path which
involves a bit of unavoidable duplication in the instantiation process.