### PR TITLE
Increase the default maxSockets setting to 100

### DIFF
--- a/lib/apps/image.js
+++ b/lib/apps/image.js
@@ -8,7 +8,16 @@ var path          = require('path'),
     check         = require('validator').check,
     utils         = require('../utils'),
     config        = require('config'),
-    reIndex       = require('popit-api').reIndex;
+    reIndex       = require('popit-api').reIndex,
+    http          = require('http');
+
+/**
+ * Increase the number of connections node can make to a single host from
+ * the default of 5. This is necessary because the image proxy might be making
+ * lots of requests to internal images on a single page, and we don't want
+ * these requests to be queued up.
+ */
+http.globalAgent.maxSockets = 100;
 
 exports.get = function( req, res, next ) {
 


### PR DESCRIPTION
This should hopefully prevent any issues with the sockets array getting filled up too quickly when proxying a large number of images from the same host.

Part of #719 