### PR TITLE
set api app to trust proxy for https/http

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -12,6 +12,8 @@ var app = module.exports = express();
 // Pretty print json in production as well as development
 app.set('json spaces', 2);
 
+app.enable('trust proxy');
+
 var api_01_app = express();
 // Ensure that these methods all require a user.
 api_01_app.post( '*', apiRequireUser, user.can('edit instance') );


### PR DESCRIPTION
We have to set this by hand as at the point the app does a chunk of its
processing the inherited version isn't in place.

Fixes #707