### PR TITLE
API versioning now happens inside the popit-api module

### DIFF
--- a/lib/apps/api/index.js
+++ b/lib/apps/api/index.js
@@ -26,19 +26,10 @@ app.use(function(req, res, next) {
   next();
 });
 
-api_01_app.get('/', function (req, res, next) {
-  res.jsonp({
-    note: "This is the API entry point - use a '*_api_url' link in 'meta' to search a collection.",
-    meta: {
-      persons_api_url: req.apiBaseUrl + '/persons',
-      organizations_api_url: req.apiBaseUrl + '/organizations',
-      memberships_api_url: req.apiBaseUrl + '/memberships',
-      posts_api_url: req.apiBaseUrl + '/posts',
-      image_proxy_url: req.baseUrl + config.image_proxy.path,
-    },
-  });
-});
-
+/*
+ * This is here rather than in the api as it's information about
+ * this instance so not an API call.
+ */
 api_01_app.get('/about', function (req, res, next) {
   var about_object = about();
   var about_info = about_object.load_about_data(req, function(result){
@@ -61,11 +52,11 @@ api_01_app.use( function(req, res, next) {
 });
 
 // Load the various different API versions
-app.use( '/v0.1', api_01_app );
+app.use( '/', api_01_app );
 
 app.get('/', function (req, res) {
   res.render('api/index.html');
-});     
+});
 
 app.all('*', function(req, res, next) {
   // 404

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1334,7 +1334,7 @@
     },
     "popit-api": {
       "version": "0.0.14",
-      "from": "git://github.com/mysociety/popit-api.git#master",
+      "from": "popit-api@git://github.com/mysociety/popit-api.git#04a02862f2fad8aad360da315c792b2615905989",
       "resolved": "git://github.com/mysociety/popit-api.git#04a02862f2fad8aad360da315c792b2615905989",
       "dependencies": {
         "JSV": {


### PR DESCRIPTION
Just mount the api on /api and also remove the api info call which has
also been moved down into the API module.

The /about call remains in the UI layer as it contains some info which
is specific to the UI like alt-language etc.