### PR TITLE
Add license text that's customisable per-instance

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -61,6 +61,14 @@ module.exports = {
         email_from: 'DO NOT REPLY <popit@mysociety.org>',
 
         language: 'en',
+
+        // Text taken from http://opendatacommons.org/licenses/odbl/
+        license: [
+          'The **{{name}}** PopIt instance is made available under the',
+          '[Open Database License](http://opendatacommons.org/licenses/odbl/1.0/).',
+          'Any rights in individual contents of the database are licensed under the',
+          '[Database Contents License](http://opendatacommons.org/licenses/dbcl/1.0/).',
+        ].join(' '),
     },
     
 };

--- a/instance-app/app.js
+++ b/instance-app/app.js
@@ -44,6 +44,7 @@ app.use(popitApiStorageSelector({
 }));
 
 app.use( require('../lib/middleware/disclaimer') );
+app.use( require('../lib/middleware/license') );
 app.use( require('../lib/apps/auth').middleware );
 app.use( require('../lib/apps/auth').app );
 app.use(accept);

--- a/instance-app/views/html_footer.html
+++ b/instance-app/views/html_footer.html
@@ -10,6 +10,10 @@
           <p>This is the <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">alpha</a> of <a href="<%= config.hosting_server.base_url %>">PopIt</a>, a new service that lowers the barrier to starting up transparency projects.</p>
           <% } %>
 
+          <div class="license">
+            <%= license %>
+          </div>
+
           <p>PopIt is a <a href="http://poplus.org/">Poplus Component</a>: please do join the <a href="https://groups.google.com/forum/#!forum/poplus">Poplus mailing list</a> for community, support and queries. PopIt is Open Source and its <a href="https://github.com/mysociety/popit">source code is available on GitHub</a>.</p>
         </div>
 

--- a/lib/apps/about.js
+++ b/lib/apps/about.js
@@ -23,7 +23,8 @@ module.exports = function () {
     "contact_email":      { type: "textbox",  label: "Contact Email"                   },
     "contact_phone":      { type: "textbox",  label: "Contact Phone"                   },
     "disclaimer":         { type: "textarea", label: "Override disclaimer"             },
-    "no-spider":          { type: "checkbox",  label: "Do Not Spider"                  },
+    "no-spider":          { type: "checkbox", label: "Do Not Spider"                   },
+    "license":            { type: "textarea", label: "License text"                    },
   };
   
   // create an array of the field names

--- a/lib/middleware/license.js
+++ b/lib/middleware/license.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var marked = require('marked');
+var hogan = require('hogan.js');
+
+function render(text, locals) {
+  var template = hogan.compile(text);
+  var rendered = template.render(locals);
+  return marked(rendered, { sanitize: true });
+}
+
+module.exports = function licenseMiddleware(req, res, next) {
+  var license = req.popit.setting('license');
+  res.locals.license = render(license, { name: req.popit.pretty_name() });
+  next();
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -977,6 +977,11 @@
         }
       }
     },
+    "marked": {
+      "version": "0.3.2",
+      "from": "marked@",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
+    },
     "mime": {
       "version": "1.2.7",
       "from": "https://registry.npmjs.org/mime/-/mime-1.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "iconv": ">= 1.2.3",
     "image-proxy": "0.0.2",
     "language-tags": "~1.0.2",
+    "marked": "^0.3.2",
     "mime": ">= 1.2.7",
     "mkdirp": ">= 0.3.1",
     "mongodb": ">= 0.9.9-7",


### PR DESCRIPTION
Adds a license field to the instance's about page, defaulting to the [ODbL](http://opendatacommons.org/licenses/odbl/). This allows the user to specify their own custom license for the data in an instance.

Fixes #117 