### PR TITLE
Only render license when there is a valid instance

### DIFF
--- a/instance-app/views/html_footer.html
+++ b/instance-app/views/html_footer.html
@@ -6,13 +6,14 @@
         <div class="col-sm-5">
           <% if (popit) { %>
             <p><strong><%- popit.pretty_name() %></strong> is an instance of PopIt, a new service that lowers the barrier to starting up transparency projects.</p>
+
+            <div class="license">
+              <%= license %>
+            </div>
+
           <% } else { %>
           <p>This is the <a href="http://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha">alpha</a> of <a href="<%= config.hosting_server.base_url %>">PopIt</a>, a new service that lowers the barrier to starting up transparency projects.</p>
           <% } %>
-
-          <div class="license">
-            <%= license %>
-          </div>
 
           <p>PopIt is a <a href="http://poplus.org/">Poplus Component</a>: please do join the <a href="https://groups.google.com/forum/#!forum/poplus">Poplus mailing list</a> for community, support and queries. PopIt is Open Source and its <a href="https://github.com/mysociety/popit">source code is available on GitHub</a>.</p>
         </div>


### PR DESCRIPTION
Previously the code was trying to render a license even when there was no instance found, which resulted in a 500 error rather than a 404.

Fixes #733 