### PR TITLE
Fix vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,9 @@ Vagrant.configure("2") do |config|
   end
 
   # Provision using the shell provisioner
-  config.vm.provision :shell, :path => "config/provision.sh"
+  config.vm.provision :shell,
+    :path => "config/provision.sh",
+    :privileged => false
 end
 
 # If you want to add additional configuration options then create a file

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,7 @@ POPIT_VAGRANT_EXTRAS = ENV['POPIT_VAGRANT_EXTRAS']
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "hashicorp/precise64"
 
   config.vm.network :forwarded_port, guest: 3000, host: POPIT_VAGRANT_PORT
 

--- a/config/development.js-example
+++ b/config/development.js-example
@@ -28,5 +28,6 @@ module.exports = {
         send_by_transport: true,
         save_to_database:  true,
         print_to_console:  true,
+        bcc_to_sender:     false,
     },
 };

--- a/config/provision.sh
+++ b/config/provision.sh
@@ -24,7 +24,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
 sudo gem install sass --version=3.2.14 --no-rdoc --no-ri
 sudo gem install compass --version=0.12.2 --no-rdoc --no-ri
 
-echo "cd /vagrant" >> /home/vagrant/.bashrc
+grep -qG 'cd /vagrant' "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"
 cd /vagrant
 
 make

--- a/config/provision.sh
+++ b/config/provision.sh
@@ -2,55 +2,27 @@
 
 set -e
 
-# To prevent "dpkg-preconfigure: unable to re-open stdin: No such file or directory" warnings
-export DEBIAN_FRONTEND=noninteractive
-
-# Abort provisioning if toolchain is already installed
-command -v make chromium-browser npm mongo Xvfb chromedriver git >/dev/null 2>&1 &&
-{ echo "Everything already installed."; exit 0; }
-
-# Update package index before we start
-apt-get update -y
-
 # Instructions from: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
-apt-get install -y python-software-properties
-add-apt-repository -y ppa:chris-lea/node.js
-apt-get update -y
-apt-get install -y python g++ make nodejs
+wget -qO - https://deb.nodesource.com/setup | sudo bash -
 
 # Instructions from: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
-apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list
-apt-get update -y
-apt-get install -y mongodb-org
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 
-# Install elasticsearch
-wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
-echo 'deb http://packages.elasticsearch.org/elasticsearch/0.90/debian stable main' > /etc/apt/sources.list.d/elasticsearch.list
-apt-get update -y
-apt-get install -y openjdk-6-jre elasticsearch
+# Instructions from: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/setup-repositories.html
+wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
+echo 'deb http://packages.elasticsearch.org/elasticsearch/0.90/debian stable main' | sudo tee /etc/apt/sources.list.d/elasticsearch.list
 
-# Install other packages
-apt-get install -y ruby1.9.1 ruby1.9.1-dev chromium-browser xvfb git imagemagick graphicsmagick unzip postfix
+# Install packages
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  nodejs build-essential \
+  mongodb-org \
+  openjdk-6-jre elasticsearch \
+  git imagemagick graphicsmagick postfix
 
-# Download and install chromedriver
-wget -q http://chromedriver.storage.googleapis.com/2.8/chromedriver_linux64.zip
-unzip chromedriver_linux64.zip
-rm chromedriver_linux64.zip
-mv chromedriver /usr/local/bin
-chmod 755 /usr/local/bin/chromedriver
-
-# Install compass, watir-webdriver and pry
-gem install watir-webdriver --version=0.6.7 --no-rdoc --no-ri
-gem install pry --version=0.9.12.6 --no-rdoc --no-ri
-gem install sass --version=3.2.14 --no-rdoc --no-ri
-gem install compass --version=0.12.2 --no-rdoc --no-ri
-
-# Set up Xvfb to run all the time on display :99
-Xvfb :99 -ac &
-cp /etc/rc.local /etc/rc.local.old
-sed -i 's/^exit 0/Xvfb :99 -ac\n\nexit 0/' /etc/rc.local
-echo "export DISPLAY=:99" >> /home/vagrant/.bashrc
+sudo gem install sass --version=3.2.14 --no-rdoc --no-ri
+sudo gem install compass --version=0.12.2 --no-rdoc --no-ri
 
 echo "cd /vagrant" >> /home/vagrant/.bashrc
 cd /vagrant


### PR DESCRIPTION
- Don't run the script as root, use sudo instead when needed
- Remove checks at start of script, vagrant only provisions once anyway
- Remove unused packages used for headless browser testing
- Update install steps for node and elasticsearch
- Update Vagrantfile to use new-style box reference
- Stop bcc-ing emails to the sender in development by default