### PR TITLE
Don't show setup for anonymous users

### DIFF
--- a/instance-app/views/index.html
+++ b/instance-app/views/index.html
@@ -6,7 +6,9 @@
   }
 ) %>
 
-<% if (typeof current_step !== 'undefined') { %>
+<% if (!user) { %>
+  <% // Don't render anything set up instance screen %>
+<% } else if (typeof current_step !== 'undefined') { %>
 
   <div class="homepage-setup-guide container <% if (person_count + organization_count === 0) { %>solo<% } %>">
     <div class="container">


### PR DESCRIPTION
When a user that isn't an instance owner/editor visits and instance they shouldn't see the setup instance box as it's not relevant to them.

Fixes https://github.com/mysociety/popit/issues/754