### PR TITLE
Make sure ids are properly encoded in urls

### DIFF
--- a/lib/schemas/membership.js
+++ b/lib/schemas/membership.js
@@ -27,7 +27,7 @@ var MembershipSchema = module.exports = new Schema({
 }, { strict: false, collection: 'memberships' } );
 
 MembershipSchema.virtual('url').get(function() {
-  return '/' + this.constructor.collection.name + '/' + this._id;
+  return '/' + this.constructor.collection.name + '/' + encodeURIComponent(this._id);
 });
 
 MembershipSchema

--- a/lib/schemas/organization.js
+++ b/lib/schemas/organization.js
@@ -51,7 +51,7 @@ var OrganizationSchema = module.exports = new Schema({
 }, { strict: false, collection: 'organizations' } );
 
 OrganizationSchema.virtual('url').get(function() {
-  return '/' + this.constructor.collection.name + '/' + this._id;
+  return '/' + this.constructor.collection.name + '/' + encodeURIComponent(this._id);
 });
 
 OrganizationSchema.virtual('initials').get(function() {

--- a/lib/schemas/person.js
+++ b/lib/schemas/person.js
@@ -83,7 +83,7 @@ var PersonSchema = module.exports = new Schema({
 
 
 PersonSchema.virtual('url').get(function() {
-  return '/' + this.constructor.collection.name + '/' + this._id;
+  return '/' + this.constructor.collection.name + '/' + encodeURIComponent(this._id);
 });
 
 PersonSchema.virtual('initials').get(function() {

--- a/lib/schemas/post.js
+++ b/lib/schemas/post.js
@@ -24,7 +24,7 @@ var PostSchema = module.exports = new Schema({
 }, { strict: false, collection: 'posts' } );
 
 PostSchema.virtual('url').get(function() {
-  return '/' + this.constructor.collection.name + '/' + this._id;
+  return '/' + this.constructor.collection.name + '/' + encodeURIComponent(this._id);
 });
 
 PostSchema.virtual('initials').get(function() {


### PR DESCRIPTION
Use encodeURIComponent when generating a url for models so that special characters are properly escaped.

Fixes #769 