### PR TITLE
Encode record id whenever it's included in a url

### DIFF
--- a/instance-app/views/organization/edit.html
+++ b/instance-app/views/organization/edit.html
@@ -37,7 +37,7 @@
   <div class="container">
     <div class="btn-toolbar pull-right view-mode">
       <div class="btn-group">
-        <a class="btn btn-default" href="/api/v0.1/organizations/<%- organization.id %>">Get this data</a>
+        <a class="btn btn-default" href="/api/v0.1/organizations/<%- encodeURIComponent(organization.id) %>">Get this data</a>
       </div>
       <div class="btn-group">
         <% if (userCan('edit instance')) { %>

--- a/instance-app/views/organization/view.html
+++ b/instance-app/views/organization/view.html
@@ -25,7 +25,7 @@
   <div class="container">
     <div class="btn-toolbar pull-right view-mode">
       <div class="btn-group">
-        <a class="btn btn-default" href="/api/v0.1/organizations/<%- organization.id %>">Get this data</a>
+        <a class="btn btn-default" href="/api/v0.1/organizations/<%- encodeURIComponent(organization.id) %>">Get this data</a>
       </div>
       <div class="btn-group">
         <% if (userCan('edit instance')) { %>

--- a/instance-app/views/person/view.html
+++ b/instance-app/views/person/view.html
@@ -33,7 +33,7 @@
   <div class="container">
     <div class="btn-toolbar pull-right view-mode">
       <div class="btn-group">
-        <a class="btn btn-default" href="/api/v0.1/persons/<%- person.id %>">Get this data</a>
+        <a class="btn btn-default" href="/api/v0.1/persons/<%- encodeURIComponent(person.id) %>">Get this data</a>
       </div>
       <div class="btn-group">
         <% if (userCan('edit instance')) { %>

--- a/instance-app/views/post/view.html
+++ b/instance-app/views/post/view.html
@@ -10,7 +10,7 @@
   <div class="container">
     <div class="btn-toolbar pull-right view-mode">
       <div class="btn-group">
-        <a class="btn btn-default" href="/api/v0.1/posts/<%- post.id %>">Get this data</a>
+        <a class="btn btn-default" href="/api/v0.1/posts/<%- encodeURIComponent(post.id) %>">Get this data</a>
       </div>
     </div>
     <p><a href="/posts">Posts</a> / <a href="<%- post.url %>"><%- post.label %></a></p>

--- a/lib/apps/organization.js
+++ b/lib/apps/organization.js
@@ -117,7 +117,7 @@ module.exports = function () {
         // there is a bug that means we sometimes failed to create the id
         // key so fallback to _id if that's the case
         var id = organization.id ? organization.id : organization._id;
-        res.redirect('/organizations/' + id );
+        res.redirect('/organizations/' + encodeURIComponent(id) );
       });
     });
   });

--- a/lib/apps/person.js
+++ b/lib/apps/person.js
@@ -128,7 +128,7 @@ module.exports = function () {
           // there is a bug that means we sometimes failed to create the id
           // key so fallback to _id if that's the case
           var id = person.id ? person.id : person._id;
-          res.redirect('/persons/' + id);
+          res.redirect('/persons/' + encodeURIComponent(id));
         }
       });
     });


### PR DESCRIPTION
This ensures that '?', '/' and other characters are properly encoded in the url so there are no accidental 404s.

Fixes https://github.com/mysociety/popit/issues/769