### PR TITLE
Show rendered license text on about page

### DIFF
--- a/instance-app/views/about/index.html
+++ b/instance-app/views/about/index.html
@@ -26,6 +26,8 @@
       <dd class="about-field about-field-<%- val.key %>">
         <% if ( val.type == 'checkbox' ) { %>
           <%- val.value ? 'Yes' : 'No' %>
+        <% } else if (field === 'license') { %>
+          <%= license %>
         <% } else { %>
           <%- val.value %>
         <% } %>

--- a/lib/apps/about.js
+++ b/lib/apps/about.js
@@ -24,7 +24,7 @@ module.exports = function () {
     "contact_phone":      { type: "textbox",  label: "Contact Phone"                   },
     "disclaimer":         { type: "textarea", label: "Override disclaimer"             },
     "no-spider":          { type: "checkbox", label: "Do Not Spider"                   },
-    "license":            { type: "textarea", label: "License text"                    },
+    "license":            { type: "textarea", label: "License"                         },
   };
   
   // create an array of the field names


### PR DESCRIPTION
Make sure the rendered version of the license text is shown on the about page when not in editing mode. This means that visitors to the instance can see the proper license text, rather than the template that's used to generate the license text in the footer.

Fixes #745 