### PR TITLE
Add a vagrant post-up message

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,16 @@ POPIT_VAGRANT_PORT = ENV['POPIT_VAGRANT_PORT'] || 3000
 POPIT_VAGRANT_MEMORY = ENV['POPIT_VAGRANT_MEMORY'] || 1024
 POPIT_VAGRANT_EXTRAS = ENV['POPIT_VAGRANT_EXTRAS']
 
+$post_up_message = "To start PopIt run the following command:
+
+$ vagrant ssh -c 'cd /vagrant; npm start'
+
+and then visit http://www.127.0.0.1.xip.io:3000/
+
+To run the tests run the following command:
+
+$ vagrant ssh -c 'cd /vagrant; npm test'"
+
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "hashicorp/precise64"
@@ -20,6 +30,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell,
     :path => "config/provision.sh",
     :privileged => false
+
+  config.vm.post_up_message = $post_up_message
 end
 
 # If you want to add additional configuration options then create a file


### PR DESCRIPTION
Give the users some information about what they can do after they've ran 'vagrant up', including starting the popit app server and running the tests.