### PR TITLE
Improve instance label validation and behaviour.

### DIFF
--- a/hosting-app/views/instance_new.html
+++ b/hosting-app/views/instance_new.html
@@ -28,7 +28,10 @@
       <% if (errors.slug == 'slug_not_unique' ) { %>
       <span class="help-block">A Popit instance with that name already exists at <a href="<%= existing_instance_url %>"><%= existing_instance_url %></a></span>
       <% } else if (errors.slug) { %>
-        <span class="help-block">Your website name can only contain letters and numbers. It should be at least four letters long but no longer than 20.</span>
+        <span class="help-block">Your website name can only contain letters,
+        numbers, and hyphens. It should be at least four letters long but no
+        longer than <%= (63 - config.MongoDB.popit_prefix.length) %>.</span>
+
       <% } %>
     </p>
 

--- a/lib/schemas/instance.js
+++ b/lib/schemas/instance.js
@@ -12,13 +12,15 @@ var mongoose          = require('mongoose'),
     http              = require('http'),
     async             = require('async');
 
+// Need to account for popit_prefix length in maximum length of slug
+var max_slug_length = 63 - config.MongoDB.popit_prefix.length;
 
 var InstanceSchema = new Schema({
   slug: {
     type:      String,
     lowercase: true,
     trim:      true,
-    match:     [/^[a-z][a-z0-9\-]{3,19}$/, 'regexp'],
+    match:     [new RegExp("^[a-z0-9][a-z0-9\-]{2," + (max_slug_length-2) + "}[a-z0-9]$"), 'regexp'],
     validate:  [
     function( v, fn ) {
       // run on insert only, when we don't have an ID


### PR DESCRIPTION
Increase the maximum label length to 63, allow labels to start with a
number, but don't allow them to end with a hyphen. Explain that hyphens
are allowed in the validation text.