### PR TITLE
Don't redirect the homepage for popit

### DIFF
--- a/hosting-app/routes/index.js
+++ b/hosting-app/routes/index.js
@@ -11,13 +11,7 @@ var async = require('async');
 exports.route = function (app) {
 
   app.get('/', function(req, res){
-    // Redirect production site to the documentation site for now.
-    // TODO: Undo this once we're happy with the homepage.
-    if (req.host === 'popit.mysociety.org') {
-      res.redirect('http://popit.poplus.org/');
-    } else {
-      res.render('index.html');
-    }
+    res.render('index.html');
   });
 
   app.get('/instances/new', requireUser, function(req, res, next) {


### PR DESCRIPTION
It's confusing and masks the real problem, which is that the homepage
doesn't have proper signposting to documentation and help. Hopefully by
removing the redirect we can see what the real problem with the homepage
is(/was?) and fix that instead.

<!---
@huboard:{"order":400.0,"milestone_order":808,"custom_state":""}
-->
