### PR TITLE
Update modules with security issues

### DIFF
--- a/lib/middleware/license.js
+++ b/lib/middleware/license.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var marked = require('marked');
+var md = require('markdown-it')();
 var hogan = require('hogan.js');
 
 function render(text, locals) {
   var template = hogan.compile(text);
   var rendered = template.render(locals);
-  return marked(rendered, { sanitize: true });
+  return md.render(rendered);
 }
 
 module.exports = function licenseMiddleware(req, res, next) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -316,152 +316,152 @@
       "resolved": "https://registry.npmjs.org/doublemetaphone/-/doublemetaphone-0.1.0.tgz"
     },
     "express": {
-      "version": "3.19.2",
-      "from": "https://registry.npmjs.org/express/-/express-3.19.2.tgz",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.19.2.tgz",
+      "version": "3.20.2",
+      "from": "express@3.20.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.20.2.tgz",
       "dependencies": {
         "basic-auth": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
+          "from": "basic-auth@1.0.0",
           "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
         },
         "connect": {
-          "version": "2.28.3",
-          "from": "https://registry.npmjs.org/connect/-/connect-2.28.3.tgz",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.28.3.tgz",
+          "version": "2.29.1",
+          "from": "connect@2.29.1",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.29.1.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+              "from": "basic-auth-connect@1.0.0",
               "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
-              "version": "1.10.2",
-              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.2.tgz",
-              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.2.tgz",
+              "version": "1.12.2",
+              "from": "body-parser@~1.12.2",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.2.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.6",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.6.tgz"
+                  "version": "0.4.7",
+                  "from": "iconv-lite@0.4.7",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
                 },
                 "on-finished": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                  "from": "on-finished@~2.2.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+                      "from": "ee-first@1.1.0",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
                     }
                   }
                 },
                 "raw-body": {
-                  "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.2.tgz"
+                  "version": "1.3.3",
+                  "from": "raw-body@1.3.3",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
                 }
               }
             },
             "bytes": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+              "from": "bytes@1.0.0",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
             "cookie-parser": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.3.tgz"
+              "version": "1.3.4",
+              "from": "cookie-parser@~1.3.4",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.4.tgz"
             },
             "compression": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/compression/-/compression-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/compression/-/compression-1.3.1.tgz",
+              "version": "1.4.3",
+              "from": "compression@~1.4.3",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.4.3.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
+                  "version": "1.2.5",
+                  "from": "accepts@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.0.9",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "version": "2.0.10",
+                      "from": "mime-types@~2.0.10",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.7.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                          "version": "1.8.0",
+                          "from": "mime-db@~1.8.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+                      "version": "0.5.1",
+                      "from": "negotiator@0.5.1",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
                     }
                   }
                 },
                 "compressible": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
+                  "from": "compressible@~2.0.2",
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.7.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                      "version": "1.8.0",
+                      "from": "mime-db@~1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                     }
                   }
                 }
               }
             },
             "connect-timeout": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.5.0.tgz",
+              "version": "1.6.1",
+              "from": "connect-timeout@~1.6.1",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.1.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.0",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+                  "from": "ms@0.7.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                 }
               }
             },
             "csurf": {
-              "version": "1.6.6",
-              "from": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
-              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
+              "version": "1.7.0",
+              "from": "csurf@~1.7.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.7.0.tgz",
               "dependencies": {
                 "csrf": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/csrf/-/csrf-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.5.tgz",
+                  "version": "2.0.6",
+                  "from": "csrf@~2.0.6",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.6.tgz",
                   "dependencies": {
                     "base64-url": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz"
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     },
                     "rndm": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz",
+                      "from": "rndm@~1.1.0",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
                     },
                     "scmp": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
+                      "from": "scmp@1.0.0",
                       "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
                     },
                     "uid-safe": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
+                      "version": "1.1.0",
+                      "from": "uid-safe@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+                          "from": "native-or-bluebird@~1.1.2",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         }
                       }
@@ -471,59 +471,59 @@
               }
             },
             "errorhandler": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.3.3.tgz",
+              "version": "1.3.5",
+              "from": "errorhandler@~1.3.5",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.3.5.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
+                  "version": "1.2.5",
+                  "from": "accepts@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.0.9",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "version": "2.0.10",
+                      "from": "mime-types@~2.0.10",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.7.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                          "version": "1.8.0",
+                          "from": "mime-db@~1.8.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+                      "version": "0.5.1",
+                      "from": "negotiator@0.5.1",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
                     }
                   }
                 }
               }
             },
             "express-session": {
-              "version": "1.10.2",
-              "from": "https://registry.npmjs.org/express-session/-/express-session-1.10.2.tgz",
-              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.10.2.tgz",
+              "version": "1.10.4",
+              "from": "express-session@~1.10.4",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.10.4.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.2.1",
-                  "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
+                  "from": "crc@3.2.1",
                   "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
                 },
                 "uid-safe": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.3.tgz",
+                  "version": "1.1.0",
+                  "from": "uid-safe@1.1.0",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                   "dependencies": {
                     "base64-url": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.0.tgz"
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     },
                     "native-or-bluebird": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+                      "from": "native-or-bluebird@~1.1.2",
                       "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                     }
                   }
@@ -531,18 +531,18 @@
               }
             },
             "finalhandler": {
-              "version": "0.3.3",
-              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
+              "version": "0.3.4",
+              "from": "finalhandler@0.3.4",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz",
               "dependencies": {
                 "on-finished": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                  "from": "on-finished@~2.2.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+                      "from": "ee-first@1.1.0",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
                     }
                   }
@@ -550,40 +550,40 @@
               }
             },
             "http-errors": {
-              "version": "1.2.8",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
+              "version": "1.3.1",
+              "from": "http-errors@~1.3.1",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                  "from": "statuses@1",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "method-override": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/method-override/-/method-override-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.1.tgz"
+              "version": "2.3.2",
+              "from": "method-override@~2.3.2",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.2.tgz"
             },
             "morgan": {
-              "version": "1.5.1",
-              "from": "https://registry.npmjs.org/morgan/-/morgan-1.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.1.tgz",
+              "version": "1.5.2",
+              "from": "morgan@~1.5.2",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.2.tgz",
               "dependencies": {
                 "on-finished": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                  "from": "on-finished@~2.2.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+                      "from": "ee-first@1.1.0",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
                     }
                   }
@@ -592,125 +592,130 @@
             },
             "multiparty": {
               "version": "3.3.2",
-              "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+              "from": "multiparty@3.3.2",
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                  "from": "stream-counter@~0.2.0",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz",
+              "from": "on-headers@~1.0.0",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "qs": {
-              "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+              "version": "2.4.1",
+              "from": "qs@2.4.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
             },
             "response-time": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/response-time/-/response-time-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.2.0.tgz"
+              "version": "2.3.0",
+              "from": "response-time@~2.3.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.0.tgz"
             },
             "serve-favicon": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.2.0.tgz",
+              "from": "serve-favicon@~2.2.0",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.0",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+                  "from": "ms@0.7.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
                 }
               }
             },
             "serve-index": {
-              "version": "1.6.1",
-              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.1.tgz",
+              "version": "1.6.3",
+              "from": "serve-index@~1.6.3",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.3.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz",
+                  "version": "1.2.5",
+                  "from": "accepts@~1.2.5",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
                   "dependencies": {
                     "negotiator": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+                      "version": "0.5.1",
+                      "from": "negotiator@0.5.1",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
                     }
                   }
                 },
                 "batch": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz",
+                  "from": "batch@0.5.2",
                   "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
                 },
                 "mime-types": {
-                  "version": "2.0.9",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "version": "2.0.10",
+                  "from": "mime-types@~2.0.10",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.7.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                      "version": "1.8.0",
+                      "from": "mime-db@~1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                     }
                   }
                 }
               }
             },
             "serve-static": {
-              "version": "1.8.1",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz"
+              "version": "1.9.2",
+              "from": "serve-static@~1.9.2",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
             },
             "type-is": {
-              "version": "1.5.7",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "version": "1.6.1",
+              "from": "type-is@~1.6.1",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
               "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
                 "mime-types": {
-                  "version": "2.0.9",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "version": "2.0.10",
+                  "from": "mime-types@~2.0.10",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.7.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                      "version": "1.8.0",
+                      "from": "mime-db@~1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
                     }
                   }
                 }
@@ -718,147 +723,157 @@
             },
             "vhost": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz",
+              "from": "vhost@~3.0.0",
               "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+              "from": "pause@0.0.1",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
+          "from": "content-disposition@0.5.0",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+        },
+        "content-type": {
+          "version": "1.0.1",
+          "from": "content-type@~1.0.1",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "commander": {
           "version": "2.6.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "from": "commander@2.6.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
         "cookie-signature": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+          "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
-          "version": "2.1.1",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+          "version": "2.1.3",
+          "from": "debug@~2.1.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "dependencies": {
             "ms": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz",
+          "from": "depd@~1.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+          "from": "escape-html@1.0.1",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+          "from": "etag@~1.5.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
-              "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
+              "from": "crc@3.2.1",
               "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.2.4",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
+          "from": "fresh@0.2.4",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
-        "media-typer": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+        "merge-descriptors": {
+          "version": "1.0.0",
+          "from": "merge-descriptors@1.0.0",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
         },
         "methods": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
+          "from": "methods@~1.1.1",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
+          "from": "parseurl@~1.3.0",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.6.tgz",
+          "version": "1.0.7",
+          "from": "proxy-addr@~1.0.7",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "from": "forwarded@~0.1.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "0.1.8",
-              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.8.tgz"
+              "version": "0.1.9",
+              "from": "ipaddr.js@0.1.9",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
             }
           }
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
+          "from": "range-parser@~1.0.2",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
-          "version": "0.11.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
+          "version": "0.12.2",
+          "from": "send@0.12.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+              "from": "destroy@1.0.3",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "mime": {
-              "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "version": "1.3.4",
+              "from": "mime@1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.0",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+              "from": "ms@0.7.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
             },
             "on-finished": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+              "from": "on-finished@~2.2.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+                  "from": "ee-first@1.1.0",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
                 }
               }
@@ -867,23 +882,13 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
+          "from": "vary@~1.0.0",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
-        },
-        "cookie": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-        },
-        "merge-descriptors": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -987,10 +987,49 @@
         }
       }
     },
-    "marked": {
-      "version": "0.3.2",
-      "from": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.2.tgz"
+    "markdown-it": {
+      "version": "4.1.0",
+      "from": "markdown-it@",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.1.0.tgz",
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.2",
+          "from": "argparse@~1.0.0",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.6.0",
+              "from": "lodash@>= 3.2.0 < 4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+            },
+            "sprintf-js": {
+              "version": "1.0.2",
+              "from": "sprintf-js@~1.0.2",
+              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+            }
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "from": "entities@~1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+        },
+        "linkify-it": {
+          "version": "1.0.0",
+          "from": "linkify-it@~1.0.0",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.0.0.tgz"
+        },
+        "mdurl": {
+          "version": "1.0.0",
+          "from": "mdurl@~1.0.0",
+          "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.0.tgz"
+        },
+        "uc.micro": {
+          "version": "1.0.0",
+          "from": "uc.micro@^1.0.0",
+          "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz"
+        }
+      }
     },
     "mime": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "consolidate": ">= 0.5.0",
     "csv": ">= 0.0.13",
     "doublemetaphone": "*",
-    "express": "^3.19.2",
+    "express": "^3.20.2",
     "fs-extra": ">= 0.10.0",
     "hogan.js": ">= 2.0.0",
     "http-accept": "~0.1.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "iconv": ">= 1.2.3",
     "image-proxy": "0.0.4",
     "language-tags": "~1.0.2",
-    "marked": "^0.3.2",
+    "markdown-it": "^4.1.0",
     "mime": ">= 1.2.7",
     "mkdirp": ">= 0.3.1",
     "mmmagic": "^0.3.13",


### PR DESCRIPTION
I haven't fixed the issue with the `connect` module that I mentioned as that's only an issue for the version of connect that `kue` depends on, and we're not using any of kue's express interface so there's no real need to fix that particular issue. I've marked it as closed on Gemnasium.

Fixes #798 