### PR TITLE
Update image-proxy to 0.0.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -937,9 +937,9 @@
       "resolved": "https://registry.npmjs.org/iconv/-/iconv-1.2.4.tgz"
     },
     "image-proxy": {
-      "version": "0.0.4",
-      "from": "https://registry.npmjs.org/image-proxy/-/image-proxy-0.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/image-proxy/-/image-proxy-0.0.4.tgz",
+      "version": "0.0.6",
+      "from": "https://registry.npmjs.org/image-proxy/-/image-proxy-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/image-proxy/-/image-proxy-0.0.6.tgz",
       "dependencies": {
         "gm": {
           "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hogan.js": ">= 2.0.0",
     "http-accept": "~0.1.6",
     "iconv": ">= 1.2.3",
-    "image-proxy": "0.0.4",
+    "image-proxy": "0.0.6",
     "language-tags": "~1.0.2",
     "marked": "^0.3.2",
     "mime": ">= 1.2.7",


### PR DESCRIPTION
Fixes the gamma problem when resizing images using image-proxy

Resolves https://github.com/mysociety/yournextmp-popit/issues/288
Closes #824 