### PR TITLE
Restart the application after deploying it

### DIFF
--- a/config/post_deploy_actions.bash
+++ b/config/post_deploy_actions.bash
@@ -54,3 +54,9 @@ make all public-production
 
 # Take a copy of the updated node_modules directory.
 cp -R "$RELEASE_DIR/node_modules" "$CACHE_DIR/"
+
+TMP_DIR="$VHOST_ROOT/tmp"
+mkdir -p "$TMP_DIR"
+
+# Restart the application
+touch "$TMP_DIR/restart.txt"


### PR DESCRIPTION
This uses passenger's tmp/restart.txt mechanism to restart popit at the end of the deploy. There is still a very brief bit of downtime because of [this bit of code in `deploy-vhost`](https://github.com/mysociety/misc-scripts/blob/6bd32763d03898885e448fbf20b11e5214dc8011/bin/deploy-vhost#L505-L514), but it's kept to an absolute minimum.

Fixes #659 