### PR TITLE
Disable new instance creation

### DIFF
--- a/hosting-app/routes/index.js
+++ b/hosting-app/routes/index.js
@@ -14,38 +14,16 @@ exports.route = function (app) {
     res.render('index.html');
   });
 
+  app.get('/instance_creation_disabled', function(req, res, next) {
+    res.render('instance_creation_disabled.html');
+  });
+
   app.get('/instances/new', requireUser, function(req, res, next) {
-    res.locals.errors = {};
-    res.locals.slug = '';
-    res.render('instance_new.html');
+    return res.redirect('/instance_creation_disabled');
   });
 
   app.post('/instances/new', requireUser, function(req, res, next) {
-    var slug = res.locals.slug = req.param('slug', '').trim();
-    var Instance = req.popit.model('Instance');
-    var Permission = req.popit.permissions();
-    var instance = new Instance();
-    instance.slug = slug;
-    instance.email = req.user.email;
-    instance.status = 'active';
-    instance.save(function(err, newInstance) {
-      if (err) {
-        res.locals.errors = err.errors;
-        res.locals.existing_instance_url = instance.base_url;
-        return res.render('instance_new.html');
-      }
-      // Make the user owner of the instance
-      Permission.create({
-        account: req.user._id,
-        instance: newInstance._id,
-        role: 'owner',
-      }, function(err) {
-        if (err) {
-          return next(err);
-        }
-        res.redirect('/instances/' + slug);
-      });
-    });
+    return res.redirect('/instance_creation_disabled');
   });
 
   app.get('/instances/:slug', function(req, res) {

--- a/hosting-app/views/html_head.html
+++ b/hosting-app/views/html_head.html
@@ -53,6 +53,12 @@
 
 <body class="brand_page <% if (path == '/') { %>homepage<% } %>">
 
+  <div id="dev-site-warning" class="alert alert-danger">
+    <strong>Development has been stopped on PopIt.</strong>
+    <span>Existing instances will be hosted until July 2016.</span>
+    <a href="https://groups.google.com/d/msg/poplus/hIFdan_rIS8/36rx3dLPCQAJ" class="btn btn-danger btn-xs">Find out more…</a></p>
+  </div>
+
   <% if ( config.show_dev_site_warning ) { %>
   <div id="dev-site-warning" class="alert alert-danger">
     <strong>This is a development site.</strong>

--- a/hosting-app/views/index.html
+++ b/hosting-app/views/index.html
@@ -14,7 +14,6 @@
         <p class="lead">PopIt helps you create, use, and maintain lists of
         public figures as structured, open data, accessible through a simple
         web&ndash;based interface.</p>
-        <a class="btn btn-primary btn-lg" href="/instances/new">Start your own PopIt</a>
         <a class="btn btn-default btn-lg" href="/instances">Browse existing PopIts</a>
       </div>
     </div>

--- a/hosting-app/views/instance_creation_disabled.html
+++ b/hosting-app/views/instance_creation_disabled.html
@@ -1,0 +1,21 @@
+<%= render(
+'html_head.html',
+{
+title:       'Instance creation is disabled',
+description: '',
+}
+) %>
+
+<div class="container hosting-app-instance-new">
+
+  <h1>Development has been stopped on PopIt.</h1>
+
+  <p class="lead">
+    As part of this we've disabled new instance creation.
+    Existing instances will be hosted until July 2016.
+  </p>
+  <a href="https://groups.google.com/d/msg/poplus/hIFdan_rIS8/36rx3dLPCQAJ" class="btn btn-primary">Find out more in the announcement post…</a></p>
+
+</div>
+
+<%= render('html_footer.html' )%>

--- a/hosting-app/views/instances.html
+++ b/hosting-app/views/instances.html
@@ -25,7 +25,6 @@
       <% } %>
     </div>
 
-    <p class="text-center"><a href="/instances/new" class="btn btn-primary">Create a PopIt</a></p>
     <% } %>
 
     <div class="list-group">

--- a/instance-app/views/html_head.html
+++ b/instance-app/views/html_head.html
@@ -61,6 +61,12 @@
 
 <body id="popit-<%- popit ? popit.instance_name() : 'no-site-found' %>" class="<%- userCan('edit instance')  ? 'signed_in instance-admin-app-active' : '' %>">
 
+  <div id="dev-site-warning" class="alert alert-danger">
+    <strong>Development has been stopped on PopIt.</strong>
+    <span>Existing instances will be hosted until July 2016.</span>
+    <a href="https://groups.google.com/d/msg/poplus/hIFdan_rIS8/36rx3dLPCQAJ" class="btn btn-danger btn-xs">Find out more…</a></p>
+  </div>
+
   <% if ( config.show_dev_site_warning ) { %>
   <div id="dev-site-warning" class="alert alert-danger">
     <strong>This is a development site.</strong>

--- a/public/sass/_hosting-app.scss
+++ b/public/sass/_hosting-app.scss
@@ -134,11 +134,6 @@
       margin-bottom: 0;
     }
   }
-  .btn-default {
-    @media (min-width: 600px) {
-      margin-left: 1em;
-    }
-  }
 }
 
 .homepage-screenshot {

--- a/test/ui/homepage.js
+++ b/test/ui/homepage.js
@@ -14,10 +14,6 @@ describe("homepage", function() {
     browser.assert.success();
   });
 
-  it("contains link to create new instance", function() {
-    browser.assert.link('a', 'Start your own PopIt', '/instances/new');
-  });
-
   it("contains link to all instances", function() {
     browser.assert.link('a', 'Browse existing PopIts', '/instances');
   });


### PR DESCRIPTION
Adds a banner linking to [Tom's mailing list post](https://groups.google.com/d/msg/poplus/hIFdan_rIS8/36rx3dLPCQAJ) about development stopping on PopIt.

![screen shot 2015-08-20 at 10 37 01](https://cloud.githubusercontent.com/assets/22996/9380660/96f84b3c-4729-11e5-8568-f6f3467010f6.png)

Disables new instance creation. The "new instance" page isn't linked to from anywhere, but if it's accessed directly then you will be redirected to `/instance_creation_disabled`, which looks like this:

![screen shot 2015-08-20 at 10 53 53](https://cloud.githubusercontent.com/assets/22996/9380681/c565a8a2-4729-11e5-83aa-4e1373985605.png)
